### PR TITLE
Add stub to all processes.

### DIFF
--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -38,7 +38,8 @@ process DIANN_SEARCH {
 
     stub:
         """
-        touch report.tsv.speclib report.tsv
+        touch report.tsv.speclib report.tsv stub.quant
+        touch stub.stderr stub.stdout
         """
 }
 
@@ -83,7 +84,8 @@ process DIANN_SEARCH_LIB_FREE {
 
     stub:
         """
-        touch report.tsv.speclib report.tsv
+        touch lib.predicted.speclib report.tsv.speclib report.tsv stub.quant
+        touch stub.stderr stub.stdout
         """
 }
 

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -117,7 +117,7 @@ process ENCYCLOPEDIA_DLIB_TO_TSV {
     publishDir "${params.result_dir}/encyclopedia/convert-blib", failOnError: true, mode: 'copy'
     label 'process_medium'
     label 'process_high_memory'
-    container encyclopedia3_mriffle
+    container params.images.encyclopedia3_mriffle
 
     input:
         path dlib

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -41,6 +41,16 @@ process ENCYCLOPEDIA_SEARCH_FILE {
         ${encyclopedia_params} \\
         > >(tee "encyclopedia-${mzml_file.baseName}.stdout") 2> >(tee "encyclopedia-${mzml_file.baseName}.stderr" >&2)
     """
+
+    stub:
+    """
+    touch stub.stderr stub.stdout
+    touch "${mzml_file}.elib"
+    touch "${mzml_file.baseName}.dia"
+    touch "${mzml_file}.features.txt"
+    touch "${mzml_file}.encyclopedia.txt"
+    touch "${mzml_file}.encyclopedia.decoy.txt"
+    """
 }
 
 process ENCYCLOPEDIA_CREATE_ELIB {
@@ -83,6 +93,14 @@ process ENCYCLOPEDIA_CREATE_ELIB {
         ${encyclopedia_params} \\
         > >(tee "${outputFilePrefix}.stdout") 2> >(tee "${outputFilePrefix}.stderr" >&2)
     """
+
+    stub:
+    """
+    touch stub.stderr stub.stdout
+    touch "${outputFilePrefix}-combined-results.elib"
+    touch "${outputFilePrefix}-combined-results.elib.peptides.txt"
+    touch "${outputFilePrefix}-combined-results.elib.proteins.txt"
+    """
 }
 
 process ENCYCLOPEDIA_BLIB_TO_DLIB {
@@ -111,6 +129,12 @@ process ENCYCLOPEDIA_BLIB_TO_DLIB {
         -f "${fasta}" \\
         > >(tee "encyclopedia-convert-blib.stdout") 2> >(tee "encyclopedia-convert-blib.stderr" >&2)
     """
+
+    stub:
+    """
+    touch stub.stderr stub.stdout
+    touch "${blib.baseName}.dlib"
+    """
 }
 
 process ENCYCLOPEDIA_DLIB_TO_TSV {
@@ -136,5 +160,11 @@ process ENCYCLOPEDIA_DLIB_TO_TSV {
         -o "${dlib.baseName}.tsv" \\
         -i "${dlib}" \\
         > >(tee "encyclopedia-convert-dlib.stdout") 2> >(tee "encyclopedia-convert-dlib.stderr" >&2)
+    """
+
+    stub:
+    """
+    touch stub.stderr stub.stdout
+    touch "${dlib.baseName}.tsv"
     """
 }

--- a/modules/panorama.nf
+++ b/modules/panorama.nf
@@ -11,17 +11,17 @@ String escapeRegex(String str) {
 
 /**
  * Get the Panorama project webdav URL for the given Panorama webdav directory
- * 
+ *
  * @param webdavDirectory The full URL to the WebDav directory on the Panorama server.
  * @return The modified URL pointing to the project's main view page.
  * @throws IllegalArgumentException if the input URL does not contain the required segments.
  */
 String getPanoramaProjectURLForWebDavDirectory(String webdavDirectory) {
     def uri = new URI(webdavDirectory)
-    
+
     def pathSegments = uri.path.split('/')
     pathSegments = pathSegments.findAll { it && it != '_webdav' }
-    
+
     int cutIndex = pathSegments.indexOf('@files')
     if (cutIndex != -1) {
         pathSegments = pathSegments.take(cutIndex)
@@ -30,7 +30,7 @@ String getPanoramaProjectURLForWebDavDirectory(String webdavDirectory) {
     def basePath = pathSegments.collect { URLEncoder.encode(it, "UTF-8") }.join('/')
     def encodedProjectView = URLEncoder.encode('project-begin.view', 'UTF-8')
     def newUrl = "${uri.scheme}://${uri.host}/${basePath}/${encodedProjectView}"
-    
+
     return newUrl
 }
 
@@ -67,11 +67,6 @@ process PANORAMA_GET_RAW_FILE_LIST {
 
     echo "Done!" # Needed for proper exit
     """
-
-    stub:
-    """
-    touch "panorama_files.txt"
-    """
 }
 
 process PANORAMA_GET_SKYLINE_TEMPLATE {
@@ -103,7 +98,8 @@ process PANORAMA_GET_SKYLINE_TEMPLATE {
 
     stub:
     """
-    touch "{$file(web_dav_dir_url).name}"
+    touch "${file(web_dav_dir_url).name}"
+    touch stub.stderr stub.stdout
     """
 }
 
@@ -136,7 +132,8 @@ process PANORAMA_GET_FASTA {
 
     stub:
     """
-    touch "{$file(web_dav_dir_url).name}"
+    touch "${file(web_dav_dir_url).name}"
+    touch stub.stderr stub.stdout
     """
 }
 
@@ -169,7 +166,8 @@ process PANORAMA_GET_SPECTRAL_LIBRARY {
 
     stub:
     """
-    touch "{$file(web_dav_dir_url).name}"
+    touch "${file(web_dav_dir_url).name}"
+    touch stub.stderr stub.stdout
     """
 }
 
@@ -202,7 +200,8 @@ process PANORAMA_GET_RAW_FILE {
 
     stub:
     """
-    touch "{$download_file_placeholder.baseName}"
+    touch "${download_file_placeholder.baseName}"
+    touch stub.stderr stub.stdout
     """
 }
 
@@ -232,11 +231,6 @@ process PANORAMA_GET_SKYR_FILE {
             > >(tee "panorama-get-${file_name}.stdout") 2> >(tee "panorama-get-${file_name}.stderr" >&2)
         echo "Done!" # Needed for proper exit
         """
-
-    stub:
-    """
-    touch "{$file(web_dav_dir_url).name}"
-    """
 }
 
 process UPLOAD_FILE {
@@ -267,6 +261,11 @@ process UPLOAD_FILE {
             > >(tee "panorama-upload-${file_name}.stdout") 2> >(tee "panorama-upload-${file_name}.stderr" >&2)
         echo "Done!" # Needed for proper exit
         """
+
+    stub:
+    '''
+    touch stub.stderr stub.stdout
+    '''
 }
 
 process IMPORT_SKYLINE {
@@ -296,4 +295,9 @@ process IMPORT_SKYLINE {
             > >(tee "panorama-import-skyline.stdout") 2> >(tee "panorama-import-skyline.stderr" >&2)
         echo "Done!" # Needed for proper exit
         """
+
+    stub:
+    '''
+    touch panorama-import-skyline.stdout panorama-import-skyline.stderr
+    '''
 }

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -33,6 +33,12 @@ process SKYLINE_ADD_LIB {
         --share-zip="results.sky.zip" \
         --share-type="complete"
     """
+
+    stub:
+    """
+    touch "results.sky.zip"
+    touch "skyline_add_library.log"
+    """
 }
 
 process SKYLINE_IMPORT_MZML {
@@ -63,6 +69,11 @@ process SKYLINE_IMPORT_MZML {
         --import-no-join \
         --log-file="${mzml_file.baseName}.log" \
         --import-file="/tmp/${mzml_file}" \
+    """
+
+    stub:
+    """
+    touch "${mzml_file.baseName}.log" "${mzml_file.baseName}.skyd"
     """
 }
 
@@ -106,6 +117,13 @@ process SKYLINE_MERGE_RESULTS {
         --share-zip="${params.skyline.document_name}.sky.zip" \
         --share-type="complete"
 
+    sky_zip_hash=\$( md5sum ${params.skyline.document_name}.sky.zip |awk '{print \$1}' )
+    """
+
+    stub:
+    """
+    touch "${params.skyline.document_name}.sky.zip"
+    touch "skyline-merge.log"
     sky_zip_hash=\$( md5sum ${params.skyline.document_name}.sky.zip |awk '{print \$1}' )
     """
 }
@@ -254,4 +272,19 @@ process SKYLINE_RUN_REPORTS {
         done
     done
     """
+
+    stub:
+    '''
+    touch stub.log
+
+    for xmlfile in ./*.skyr; do
+        awk -F'"' '/<view name=/ { print $2 }' "$xmlfile" | while read reportname; do
+            touch "${reportname}.report.tsv"
+        done
+    done
+
+    if [ $(ls *.report.tsv|wc -l) -eq 0 ] ; then
+        touch stub.report.tsv
+    fi
+    '''
 }


### PR DESCRIPTION
The nextflow `-stub` option will work with all processes with the following exceptions:

* I didn't add a stub for the `SAVE_RUN_DETAILS` process.
* When downloading raw files from panorama, the real `PANORAMA_GET_RAW_FILE_LIST` process is still called so it requires a real panorama directory with `raw` or `mzML` files.
* The `PANORAMA_GET_RAW_FILE` process will then create an empty file with the same name as the `raw` or `mzML` file.
* The stub for the `SKYLINE_RUN_REPORTS` needs a real `.skyr` file as an input in-order to produce an empty report with the expected output file name.