### PR TITLE
Consolidate QC command line output

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -6,7 +6,7 @@ params {
         panorama_client:       'quay.io/protio/panorama-client:1.1.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.0.0',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.2.2',
         proteowizard:          'quay.io/protio/pwiz-skyline-i-agree-to-the-vendor-licenses:3.0.24172-63d00b1'
     ]
 }

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -28,7 +28,7 @@ process ENCYCLOPEDIA_SEARCH_FILE {
         path("${mzml_file}.features.txt"), emit: features
         path("${mzml_file}.encyclopedia.txt"), emit: results_targets
         path("${mzml_file}.encyclopedia.decoy.txt"), emit: results_decoys
-        
+
 
     script:
     """

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -138,8 +138,8 @@ process ANNOTATION_TSV_TO_CSV {
         path replicate_metadata
 
     output:
-        path("sky_annotations.csv"), emit: annotation_csv
-        path("sky_annotation_definitions.bat"), emit: annotation_definitions
+        path("metadata.annotations.csv"), emit: annotation_csv
+        path("metadata.definitions.bat"), emit: annotation_definitions
 
     shell:
     """
@@ -148,7 +148,7 @@ process ANNOTATION_TSV_TO_CSV {
 
     stub:
     """
-    touch sky_annotation_definitions.bat  sky_annotations.csv
+    touch metadata.definitions.bat metadata.annotations.csv
     """
 }
 

--- a/workflows/generate_qc_report.nf
+++ b/workflows/generate_qc_report.nf
@@ -1,8 +1,6 @@
 
 include { SKYLINE_RUN_REPORTS } from "../modules/skyline.nf"
 include { PARSE_REPORTS } from "../modules/qc_report.nf"
-include { NORMALIZE_DB } from "../modules/qc_report.nf"
-include { GENERATE_QC_QMD } from "../modules/qc_report.nf"
 include { RENDER_QC_REPORT } from "../modules/qc_report.nf"
 include { EXPORT_TABLES } from "../modules/qc_report.nf"
 
@@ -32,15 +30,8 @@ workflow generate_dia_qc_report {
                       precursor_report,
                       replicate_metadata)
 
-        if(params.qc_report.normalization_method != null) {
-            NORMALIZE_DB(PARSE_REPORTS.out.qc_report_db)
-            qc_report_db = NORMALIZE_DB.out.qc_report_db
-        } else {
-            qc_report_db = PARSE_REPORTS.out.qc_report_db
-        }
-
-        GENERATE_QC_QMD(qc_report_db)
-        qc_report_qmd = GENERATE_QC_QMD.out.qc_report_qmd
+        qc_report_db = PARSE_REPORTS.out.qc_report_db
+        qc_report_qmd = PARSE_REPORTS.out.qc_report_qmd
 
         report_formats = Channel.fromList(['html', 'pdf'])
         RENDER_QC_REPORT(qc_report_qmd.collect(), qc_report_db.collect(),


### PR DESCRIPTION
* Consolidate commands used to build QC reports to reduce output printed to command line.
* Update `dia_qc_report` container to latest version.
* Update output file names in `ANNOTATION_TSV_TO_CSV` to names used by new version of container.