### PR TITLE
Improve Skyline reports

### DIFF
--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -112,7 +112,9 @@ The ``params`` Section
      - If set to ``true``, the generated Skyline document will be imported into PanoramaWeb's relational database for inline visualization. The import will appear in the parent folder for the ``panorama.upload_url`` parameter, and will have the named used for the ``skyline_document_name`` parameter. Default: ``false``. Note: ``panorama_upload`` must be set to ``true`` and ``skip_skyline`` must be set to ``false`` to use this feature.
    * -
      - ``skyline.skyr_file``
-     - The path (local file system or Panorama WebDAV) to a ``.skyr`` file, which is a Skyline file that specifies reports. Any reports specified in the ``.skyr`` file will be run automatically as the last step of the workflow and the results saved in your ``results`` directory and (if requested) uploaded to Panorama.
+     - Path(s) (local file system or Panorama WebDAV) to a ``.skyr`` file, which is a Skyline report template. Any reports specified in the ``.skyr`` file will be run automatically as the last step of the workflow and the results saved in your ``results`` directory and (if requested) uploaded to Panorama. The report template(s) can be a single string, or for multiple ``.skyr`` files can be given as a list of strings.
+       For example: ``'/path/to/report.skyr'`` for a single file, or
+       ``['/path/to/report_1.skyr', '/path/to/report_2.skyr']`` for multiple files.
    * -
      - ``skyline.template_file``
      - The Skyline template file used to generate the final Skyline file. By default a

--- a/modules/panorama.nf
+++ b/modules/panorama.nf
@@ -69,75 +69,7 @@ process PANORAMA_GET_RAW_FILE_LIST {
     """
 }
 
-process PANORAMA_GET_SKYLINE_TEMPLATE {
-    label 'process_low_constant'
-    label 'error_retry'
-    container params.images.panorama_client
-    publishDir "${params.result_dir}/panorama", failOnError: true, mode: 'copy', pattern: "*.stdout"
-    publishDir "${params.result_dir}/panorama", failOnError: true, mode: 'copy', pattern: "*.stderr"
-
-    input:
-        val web_dav_dir_url
-
-    output:
-        path("${file(web_dav_dir_url).name}"), emit: panorama_file
-        path("*.stdout"), emit: stdout
-        path("*.stderr"), emit: stderr
-
-    script:
-        file_name = file(web_dav_dir_url).name
-        """
-        echo "Downloading ${file_name} from Panorama..."
-            ${exec_java_command(task.memory)} \
-            -d \
-            -w "${web_dav_dir_url}" \
-            -k \$PANORAMA_API_KEY \
-            > >(tee "panorama-get-${file_name}.stdout") 2> >(tee "panorama-get-${file_name}.stderr" >&2)
-        echo "Done!" # Needed for proper exit
-        """
-
-    stub:
-    """
-    touch "${file(web_dav_dir_url).name}"
-    touch stub.stderr stub.stdout
-    """
-}
-
-process PANORAMA_GET_FASTA {
-    label 'process_low_constant'
-    label 'error_retry'
-    container params.images.panorama_client
-    publishDir "${params.result_dir}/panorama", failOnError: true, mode: 'copy', pattern: "*.stdout"
-    publishDir "${params.result_dir}/panorama", failOnError: true, mode: 'copy', pattern: "*.stderr"
-
-    input:
-        val web_dav_dir_url
-
-    output:
-        path("${file(web_dav_dir_url).name}"), emit: panorama_file
-        path("*.stdout"), emit: stdout
-        path("*.stderr"), emit: stderr
-
-    script:
-        file_name = file(web_dav_dir_url).name
-        """
-        echo "Downloading ${file_name} from Panorama..."
-            ${exec_java_command(task.memory)} \
-            -d \
-            -w "${web_dav_dir_url}" \
-            -k \$PANORAMA_API_KEY \
-            > >(tee "panorama-get-${file_name}.stdout") 2> >(tee "panorama-get-${file_name}.stderr" >&2)
-        echo "Done!" # Needed for proper exit
-        """
-
-    stub:
-    """
-    touch "${file(web_dav_dir_url).name}"
-    touch stub.stderr stub.stdout
-    """
-}
-
-process PANORAMA_GET_SPECTRAL_LIBRARY {
+process PANORAMA_GET_FILE {
     label 'process_low_constant'
     label 'error_retry'
     container params.images.panorama_client

--- a/workflows/generate_qc_report.nf
+++ b/workflows/generate_qc_report.nf
@@ -20,7 +20,7 @@ workflow generate_dia_qc_report {
 
         // export skyline reports
         skyr_files = Channel.fromList([params.qc_report.replicate_report_template,
-                                       params.qc_report.precursor_report_template]).map{ file(it) }
+                                       params.qc_report.precursor_report_template]).map{ file(it, checkIfExists: true) }
         SKYLINE_RUN_REPORTS(sky_zip_file, skyr_files.collect())
         sky_reports = SKYLINE_RUN_REPORTS.out.skyline_report_files.flatten().map{ it -> tuple(it.name, it) }
         precursor_report = sky_reports.filter{ it[0] =~ /^precursor_quality\.report\.tsv$/ }.map{ it -> it[1] }

--- a/workflows/get_input_files.nf
+++ b/workflows/get_input_files.nf
@@ -1,9 +1,9 @@
 // modules
-include { PANORAMA_GET_FASTA } from "../modules/panorama"
-include { PANORAMA_GET_SPECTRAL_LIBRARY } from "../modules/panorama"
-include { PANORAMA_GET_SKYLINE_TEMPLATE } from "../modules/panorama"
+include { PANORAMA_GET_FILE as PANORAMA_GET_FASTA } from "../modules/panorama"
+include { PANORAMA_GET_FILE as PANORAMA_GET_SPECTRAL_LIBRARY } from "../modules/panorama"
+include { PANORAMA_GET_FILE as PANORAMA_GET_SKYLINE_TEMPLATE } from "../modules/panorama"
 include { PANORAMA_GET_SKYR_FILE } from "../modules/panorama"
-include { PANORAMA_GET_FASTA as PANORAMA_GET_METADATA } from "../modules/panorama"
+include { PANORAMA_GET_FILE as PANORAMA_GET_METADATA } from "../modules/panorama"
 include { MAKE_EMPTY_FILE as METADATA_PLACEHOLDER } from "../modules/qc_report"
 
 workflow get_input_files {

--- a/workflows/get_input_files.nf
+++ b/workflows/get_input_files.nf
@@ -7,14 +7,20 @@ include { PANORAMA_GET_FILE as PANORAMA_GET_METADATA } from "../modules/panorama
 include { MAKE_EMPTY_FILE as METADATA_PLACEHOLDER } from "../modules/qc_report"
 
 /**
-* Process a parameter variable which specified as either a single value or List.
+* Process a parameter variable which is specified as either a single value or List.
+* If param_variable has multiple lines, each line with text is returned as an
+* element in a List.
 *
 * @param param_variable A parameter variable which can either be a single value or List.
-* @return param_variable A List with 1 or more values.
+* @return param_variable as a List with 1 or more values.
 */
 def param_to_list(param_variable) {
     if(param_variable instanceof List) {
         return param_variable
+    }
+    if(param_variable instanceof String) {
+        // Split string by new line, remove whitespace, and skip empty lines
+        return param_variable.split('\n').collect{ it.trim() }.findAll{ it }
     }
     return [param_variable]
 }


### PR DESCRIPTION
* Use Skyline `--batch-commands` option so the Skyline document is only opened once once when exporting reports.
* Specify `.skyr` files in `params.skyline.skyr_file` as a string or list of strings.
   - `.skyr` files can be given as either `"/path/to/skyr"` or `["/path/to/report_1.skyr", "/path/to/report_2.skyr"]`
   - Currently the way to specify multiple `skyr` files would be to separate them by a new line (`"/path/to/report_1.skyr\npath/to/report_2.skyr"`) which is a little clunky and is not in the documentation.

* Import duplicated panorama processes as an alias.
