### PR TITLE
Fix dynamic metadata file names in ANNOTATION_TSV_TO_CSV

### DIFF
--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -138,8 +138,8 @@ process ANNOTATION_TSV_TO_CSV {
         path replicate_metadata
 
     output:
-        path("metadata.annotations.csv"), emit: annotation_csv
-        path("metadata.definitions.bat"), emit: annotation_definitions
+        path("${replicate_metadata.baseName}.annotations.csv"), emit: annotation_csv
+        path("${replicate_metadata.baseName}.definitions.bat"), emit: annotation_definitions
 
     shell:
     """
@@ -148,7 +148,7 @@ process ANNOTATION_TSV_TO_CSV {
 
     stub:
     """
-    touch metadata.definitions.bat metadata.annotations.csv
+    touch ${replicate_metadata.baseName}.definitions.bat ${replicate_metadata.baseName}.annotations.csv
     """
 }
 


### PR DESCRIPTION
Fix bug where any metadata file that is not named `metadata.tsv` would not have the output file name expected by the `ANNOTATION_TSV_TO_CSV` process.