### PR TITLE
Update qc_pipeline container from 2.2.2 to 2.2.4

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -6,7 +6,7 @@ params {
         panorama_client:       'quay.io/protio/panorama-client:1.1.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.2.2',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.2.4',
         proteowizard:          'quay.io/protio/pwiz-skyline-i-agree-to-the-vendor-licenses:3.0.24172-63d00b1'
     ]
 }


### PR DESCRIPTION
This will fix an error which occurs when annotating a Skyline document when there are NAs in a metadata tsv file.