### PR TITLE
Get rid of panorama raw file placeholder files.

### DIFF
--- a/modules/panorama.nf
+++ b/modules/panorama.nf
@@ -231,9 +231,9 @@ process UPLOAD_FILE {
         """
 
     stub:
-    '''
-    touch stub.stderr stub.stdout
-    '''
+    """
+    touch "panorama-upload-${file(file_to_upload).name}.stdout" "panorama-upload-${file(file_to_upload).name}.stderr"
+    """
 }
 
 process IMPORT_SKYLINE {

--- a/workflows/get_mzmls.nf
+++ b/workflows/get_mzmls.nf
@@ -22,9 +22,12 @@ workflow get_mzmls {
                                     .filter{ it.length() > 0 } // skip empty lines
 
             // get raw files from panorama
-            panorama_raw_list_ch = PANORAMA_GET_RAW_FILE_LIST(spectra_dirs_ch, spectra_glob, aws_secret_id)
-            placeholder_ch = panorama_raw_list_ch.raw_file_placeholders.transpose()
-            PANORAMA_GET_RAW_FILE(placeholder_ch, aws_secret_id)
+            PANORAMA_GET_RAW_FILE_LIST(spectra_dirs_ch, spectra_glob, aws_secret_id)
+            raw_url_ch = PANORAMA_GET_RAW_FILE_LIST.out.raw_files
+                .splitText()
+                .map{ it -> it.strip() }
+
+            PANORAMA_GET_RAW_FILE(raw_url_ch, aws_secret_id)
             
             mzml_ch = MSCONVERT(
                 PANORAMA_GET_RAW_FILE.out.panorama_file,


### PR DESCRIPTION
* Split a text file with raw file urls into a channel instead of creating raw file place holder files.
* `PANORAMA_GET_SKYR_FILE` is kept as a separate process instead of using `PANORAMA_GET_FILE` so it can use the `storeDir` directive for caching raw files.