### PR TITLE
Skyline logging

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -112,6 +112,12 @@ workflow {
             all_mzml_ch = wide_mzml_ch
         }
 
+        // save details about this run
+        input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }
+        version_files = Channel.empty()
+        save_run_details(input_files.collect(), version_files.collect())
+        run_details_file = save_run_details.out.run_details
+
         // if requested, upload mzMLs to panorama
         if(params.panorama.upload) {
 
@@ -123,13 +129,6 @@ workflow {
                 aws_secret_id
             )
         }
-
-
-        // save details about this run
-        input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }
-        version_files = Channel.empty()
-        save_run_details(input_files.collect(), version_files.collect())
-        run_details_file = save_run_details.out.run_details
 
         return
     }

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -25,7 +25,7 @@ process SKYLINE_ADD_LIB {
     unzip !{skyline_template_zipfile}
 
     wine SkylineCmd \
-        --in="!{skyline_template_zipfile.baseName}" \
+        --in="!{skyline_template_zipfile.baseName}" --memstamp \
         --log-file=skyline_add_library.log \
         --import-fasta="!{fasta}" \
         --add-library-path="!{elib}" \
@@ -108,7 +108,7 @@ process SKYLINE_IMPORT_MZML {
     cp ${mzml_file} /tmp/${mzml_file}
 
     wine SkylineCmd \
-        --in="${skyline_zipfile.baseName}" \
+        --in="${skyline_zipfile.baseName}" --memstamp \
         --import-no-join \
         --log-file="${mzml_file.baseName}.log" \
         --import-file="/tmp/${mzml_file}" \
@@ -151,7 +151,7 @@ process SKYLINE_MERGE_RESULTS {
     cp -v ${skyd_files} /tmp/
 
     wine SkylineCmd \
-        --in="${skyline_zipfile.baseName}" \
+        --in="${skyline_zipfile.baseName}" --memstamp \
         --log-file="skyline-merge.log" \
         ${import_files_params} \
         ${params.skyline.protein_parsimony ? protein_parsimony_args : ''} \
@@ -214,7 +214,7 @@ process SKYLINE_MINIMIZE_DOCUMENT {
         unzip ${skyline_zipfile}
 
         wine SkylineCmd \
-            --in="${skyline_zipfile.baseName}" \
+            --in="${skyline_zipfile.baseName}" --memstamp \
             --chromatograms-discard-unused \
             --chromatograms-limit-noise=1 \
             --out="${sky_basename(skyline_zipfile)}_minimized.sky" \
@@ -255,7 +255,7 @@ process SKYLINE_ANNOTATE_DOCUMENT {
     unzip ${skyline_zipfile}
 
     # Create Skyline batch file with annotation definitions
-    echo '--in="${skyline_zipfile.baseName}"' > add_annotations.bat
+    echo '--in="${skyline_zipfile.baseName}" --memstamp' > add_annotations.bat
     cat ${annotation_definitions} >> add_annotations.bat
     echo '--import-annotations="${annotation_csv}"' >> add_annotations.bat
     echo '--save --out="${sky_basename(skyline_zipfile)}_annotated.sky"' >> add_annotations.bat
@@ -295,7 +295,7 @@ process SKYLINE_RUN_REPORTS {
     unzip !{skyline_zipfile}
 
     # generate skyline batch file to export reports
-    echo "--in=\\"!{skyline_zipfile.baseName}\\"" > export_reports.bat
+    echo "--in=\\"!{skyline_zipfile.baseName}\\" --memstamp" > export_reports.bat
 
     for skyrfile in ./*.skyr; do
         # Add report to document


### PR DESCRIPTION
* Add `--memstamp` to all skyline commands.
* Redirect Skyline log messages to both stdout and a file.
* Fix error where run detials file was created after it is uploaded to panorama when `params.msconvert_only = true`