### PR TITLE
Add PDC as an input file source

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -4,6 +4,7 @@ params {
         diann:                 'quay.io/protio/diann:1.8.1',
         bibliospec:            'quay.io/protio/bibliospec-linux:3.0',
         panorama_client:       'quay.io/protio/panorama-client:1.1.0',
+        pdc_client:            'quay.io/mauraisa/pdc_client:0.15',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
         qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.2.4',

--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -78,6 +78,18 @@ The ``params`` Section
      - ``search_engine``
      - Must be set to either ``'encyclopedia'`` or ``'diann'``. If set to ``'diann'``, ``chromatogram_library_spectra_dir``, ``chromatogram_library_spectra_glob``, and EncyclopeDIA-specific parameters will be ignored. Default: ``'encyclopedia'``.
    * -
+     - ``pdc.study_id``
+     - When this option is set, raw files and metadata will be downloaded from the PDC. Default: ``null``.
+   * -
+     - ``pdc.gene_level_data``
+     - A ``tsv`` file mapping gene names to NCIB gene IDs and gene metadata. Required for PDC gene reports. Default: ``null``.
+   * -
+     - ``pdc.n_raw_files``
+     - If this option is set, only ``n`` raw files are downloaded. This is useful for testing but otherwise should be ``null``.
+   * -
+     - ``pdc.client_args``
+     - Additional command line arguments passed to ``PDC_client``. Default is ``null``.
+   * -
      - ``skyline.skip``
      - If set to ``true``, will skip the creation of a Skyline document. Default: ``false``.
    * -

--- a/main.nf
+++ b/main.nf
@@ -112,6 +112,12 @@ workflow {
             all_mzml_ch = wide_mzml_ch
         }
 
+        // save details about this run
+        input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }
+        version_files = Channel.empty()
+        save_run_details(input_files.collect(), version_files.collect())
+        run_details_file = save_run_details.out.run_details
+
         // if requested, upload mzMLs to panorama
         if(params.panorama.upload) {
 
@@ -123,13 +129,6 @@ workflow {
                 aws_secret_id
             )
         }
-
-
-        // save details about this run
-        input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }
-        version_files = Channel.empty()
-        save_run_details(input_files.collect(), version_files.collect())
-        run_details_file = save_run_details.out.run_details
 
         return
     }

--- a/modules/pdc.nf
+++ b/modules/pdc.nf
@@ -1,0 +1,75 @@
+
+def format_client_args(var) {
+    ret = (var == null ? "" : var)
+    return ret
+}
+
+process GET_STUDY_METADATA {
+    publishDir "${params.result_dir}/pdc", failOnError: true, mode: 'copy'
+    errorStrategy 'retry'
+    maxRetries 5
+    label 'process_low_constant'
+    container params.images.pdc_client
+
+    input:
+        val pdc_study_id
+
+    output:
+        path('study_metadata.tsv'), emit: metadata
+        path('study_metadata_annotations.csv'), emit: skyline_annotations
+        env(study_id), emit: study_id
+        env(study_name), emit: study_name
+        path('pdc_client_version.txt'), emit: version
+
+    shell:
+    n_files_arg = params.pdc.n_raw_files == null ? "" : "--nFiles ${params.pdc.n_raw_files}"
+    pdc_client_args = params.pdc.client_args == null ? "" : params.pdc.client_args
+
+    '''
+    study_id=$(PDC_client studyID !{pdc_client_args} !{pdc_study_id} | tee study_id.txt)
+    study_name=$(PDC_client studyName --normalize !{pdc_client_args} ${study_id} | tee study_name.txt)
+    PDC_client metadata !{pdc_client_args} -f tsv !{n_files_arg} --skylineAnnotations ${study_id}
+
+    echo "pdc_client_git_repo='$GIT_REPO - $GIT_BRANCH [$GIT_SHORT_HASH]'" > pdc_client_version.txt
+    '''
+}
+
+process METADATA_TO_SKY_ANNOTATIONS {
+    label 'process_low_constant'
+    container params.images.pdc_client
+
+    input:
+        path pdc_study_metadata
+
+    output:
+        path('skyline_annotations.csv'), emit: skyline_annotations
+
+    shell:
+    '''
+    PDC_client metadataToSky !{pdc_study_metadata}
+    '''
+}
+
+process GET_FILE {
+    storeDir "${params.panorama_cache_directory}"
+    label 'process_low_constant'
+    container params.images.pdc_client
+    errorStrategy 'retry'
+    maxRetries 1
+
+    input:
+        tuple val(url), val(file_name), val(md5)
+
+    output:
+        path(file_name), emit: downloaded_file
+
+    shell:
+    '''
+    PDC_client file -o '!{file_name}' -m '!{md5}' '!{url}'
+    '''
+
+    stub:
+    """
+    touch ${file_name}
+    """
+}

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -151,3 +151,31 @@ process RENDER_QC_REPORT {
     """
 }
 
+process EXPORT_GENE_REPORTS {
+    publishDir "${params.result_dir}/gene_reports", failOnError: true, mode: 'copy'
+    label 'process_high_memory'
+    container params.images.qc_pipeline
+
+    input:
+        path batch_db
+        path gene_level_data
+        val file_prefix
+
+    output:
+        path("*.tsv"), emit: gene_reports
+        path("*.stdout"), emit: stdout
+        path("*.stderr"), emit: stderr
+
+    script:
+        """
+        dia_qc export_gene_matrix --prefix=${file_prefix} --useAliquotId \
+            '${gene_level_data}' '${batch_db}'  \
+            > >(tee "export_reports.stdout") 2> >(tee "export_reports.stderr" >&2)
+        """
+
+    stub:
+        """
+        touch stub.tsv
+        touch stub.stdout stub.stderr
+        """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,14 @@ params {
     skip_skyline = null
     skyline_skyr_file = null
 
+    // Optional PDC study settings
+    pdc.base_url = 'https://proteomic.datacommons.cancer.gov/graphql'
+    pdc.client_args = ''
+    pdc.study_id = null
+    pdc.n_raw_files = null
+    pdc.metadata_tsv = null
+    pdc.gene_level_data = null
+
     // The final skyline document will be named using this name. For example,
     // if skyline_custom_name = 'human_dia' then the final Skyline document
     // will be named "human_dia.sky.zip". When importing into PanoramaWeb--this

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,6 @@ params {
     skyline_skyr_file = null
 
     // Optional PDC study settings
-    pdc.base_url = 'https://proteomic.datacommons.cancer.gov/graphql'
     pdc.client_args = ''
     pdc.study_id = null
     pdc.n_raw_files = null

--- a/workflows/get_pdc_files.nf
+++ b/workflows/get_pdc_files.nf
@@ -1,0 +1,51 @@
+
+include { GET_STUDY_METADATA } from "../modules/pdc.nf"
+include { METADATA_TO_SKY_ANNOTATIONS } from "../modules/pdc.nf"
+include { GET_FILE } from "../modules/pdc.nf"
+include { MSCONVERT } from "../modules/msconvert.nf"
+
+workflow get_pdc_study_metadata {
+    emit:
+        study_name
+        metadata
+        annotations_csv
+
+    main:
+        if(params.pdc.metadata_tsv == null) {
+            GET_STUDY_METADATA(params.pdc.study_id)
+            metadata = GET_STUDY_METADATA.out.metadata
+            annotations_csv = GET_STUDY_METADATA.out.skyline_annotations
+            study_name = GET_STUDY_METADATA.out.study_name
+        } else {
+            metadata = Channel.fromPath(file(params.pdc.metadata_tsv, checkIfExists: true))
+            METADATA_TO_SKY_ANNOTATIONS(metadata)
+            annotations_csv = METADATA_TO_SKY_ANNOTATIONS.out
+            study_name = params.pdc.study_name
+        }
+}
+
+workflow get_pdc_files {
+    emit:
+        study_name
+        metadata
+        annotations_csv
+        wide_mzml_ch
+
+    main:
+        get_pdc_study_metadata()
+        metadata = get_pdc_study_metadata.out.metadata
+        annotations_csv = get_pdc_study_metadata.out.annotations_csv
+        study_name = get_pdc_study_metadata.out.study_name
+
+        metadata \
+            | splitCsv(header:true, sep:'\t') \
+            | map{row -> tuple(row.url, row.file_name, row.md5sum)} \
+            | GET_FILE
+
+        MSCONVERT(GET_FILE.out.downloaded_file,
+                  params.msconvert.do_demultiplex,
+                  params.msconvert.do_simasspectra)
+
+        wide_mzml_ch = MSCONVERT.out.mzml_file
+}
+


### PR DESCRIPTION
* Important new workflow parameters
   - `params.pdc.study_id` When this option is set raw files and metadata are downloaded from the PDC using the [PDC_client](https://github.com/ajmaurais/PDC_client/) to interface with the PDC.
   - `params.pdc.n_raw_files` Limit processing to `n` raw files. This is useful for testing. For now this only applies to when files are downloaded from the PDC. This might be useful as a workflow option that would apply globally.

* Code refactoring
   - `raw` files are downloaded and converted once at the beginning of `main.nf` 
   - Wide window files can be local, downloaded from Panorama or downloaded from the PDC.
   - Optional narrow window files can be local or downloaded from Panorama.
   - If `params.msconvert_only == true` the `mzML` file channel(s) are uploaded to panorama and the workflow exits.
   - Otherwise the `mzML` files are searched with EncyclopeDIA or DiaNN.