### PR TITLE
Add stub tests for PDC and msconvert-only

### DIFF
--- a/.github/workflows/push-stub-run.yml
+++ b/.github/workflows/push-stub-run.yml
@@ -14,7 +14,8 @@ jobs:
         config: [
           'test-diann.config',
           'test-encyclopedia-narrow-gpf.config',
-          'test-encyclopedia-wide-only.config'
+          'test-encyclopedia-wide-only.config',
+          'test-diann-pdc.config'
         ]
     
     steps:

--- a/.github/workflows/push-stub-run.yml
+++ b/.github/workflows/push-stub-run.yml
@@ -15,7 +15,9 @@ jobs:
           'test-diann.config',
           'test-encyclopedia-narrow-gpf.config',
           'test-encyclopedia-wide-only.config',
-          'test-diann-pdc.config'
+          'test-diann-pdc.config',
+          'test-msconvert-only-pdc.config',
+          'test-msconvert-only-local.config'
         ]
     
     steps:

--- a/main.nf
+++ b/main.nf
@@ -121,11 +121,6 @@ workflow {
 
     // only perform msconvert and terminate
     if(params.msconvert_only) {
-        // save details about this run
-        input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }
-        version_files = Channel.empty()
-        save_run_details(input_files.collect(), version_files.collect())
-        run_details_file = save_run_details.out.run_details
 
         // save details about this run
         input_files = all_mzml_ch.map{ it -> ['Spectra File', it.baseName] }

--- a/main.nf
+++ b/main.nf
@@ -335,7 +335,7 @@ workflow {
         }
 
         // annotate skyline document if replicate_metadata was specified
-        if(params.replicate_metadata != null) {
+        if(params.replicate_metadata != null || params.pdc.study_id != null) {
             skyline_annotate_doc(skyline_import.out.skyline_results,
                                  replicate_metadata)
             final_skyline_file = skyline_annotate_doc.out.skyline_results

--- a/test-resources/test-diann-pdc.config
+++ b/test-resources/test-diann-pdc.config
@@ -1,0 +1,46 @@
+//
+// A sample pipeline.config for running the TEI-REX DIA Nextflow workflow.
+//
+// See https://nf-skyline-dia-ms.readthedocs.io/en/latest/workflow_options.html
+// for a complete description of all parameters.
+//
+// Send questions, comments, ideas, bug reports, etc, to:
+// Michael Riffle <mriffle@uw.edu>
+//
+
+// params will need changed per workflow run
+params {
+
+    // the search engine to use
+    search_engine = 'diann'
+    
+    pdc.study_id = 'PDC000504'
+    pdc.n_raw_files = 2
+
+	// the background FASTA file
+    fasta = 'test-resources/test.fasta'
+
+	// options for msconvert
+    msconvert.do_demultiplex = false;          // whether or not to demultiplex with msconvert
+    msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+
+    // Skip QC report generation
+    qc_report.skip = false
+}
+
+// if running jobs locally change these to match system capabilities
+profiles {
+
+    // "standard" is the profile used when the steps of the workflow are run
+    // locally on your computer. These parameters should be changed to match
+    // your system resources (that you are willing to devote to running
+    // workflow jobs).
+    standard {
+        params.max_memory = '8.GB'
+        params.max_cpus = 4
+        params.max_time = '1.h'
+
+        params.mzml_cache_directory = './mzml_cache'
+        params.panorama_cache_directory = './raw_cache'
+    }
+}

--- a/test-resources/test-msconvert-only-local.config
+++ b/test-resources/test-msconvert-only-local.config
@@ -1,0 +1,39 @@
+//
+// A sample pipeline.config for running the TEI-REX DIA Nextflow workflow.
+//
+// See https://nf-skyline-dia-ms.readthedocs.io/en/latest/workflow_options.html
+// for a complete description of all parameters.
+//
+// Send questions, comments, ideas, bug reports, etc, to:
+// Michael Riffle <mriffle@uw.edu>
+//
+
+// params will need changed per workflow run
+params {
+    
+    chromatogram_library_spectra_dir = 'test-resources/narrow-window'
+    quant_spectra_dir = 'test-resources/wide-window'
+
+	// options for msconvert
+    msconvert.do_demultiplex = true;          // whether or not to demultiplex with msconvert
+    msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+    
+    msconvert_only = true
+}
+
+// if running jobs locally change these to match system capabilities
+profiles {
+
+    // "standard" is the profile used when the steps of the workflow are run
+    // locally on your computer. These parameters should be changed to match
+    // your system resources (that you are willing to devote to running
+    // workflow jobs).
+    standard {
+        params.max_memory = '8.GB'
+        params.max_cpus = 4
+        params.max_time = '1.h'
+
+        params.mzml_cache_directory = './mzml_cache'
+        params.panorama_cache_directory = './raw_cache'
+    }
+}

--- a/test-resources/test-msconvert-only-pdc.config
+++ b/test-resources/test-msconvert-only-pdc.config
@@ -1,0 +1,39 @@
+//
+// A sample pipeline.config for running the TEI-REX DIA Nextflow workflow.
+//
+// See https://nf-skyline-dia-ms.readthedocs.io/en/latest/workflow_options.html
+// for a complete description of all parameters.
+//
+// Send questions, comments, ideas, bug reports, etc, to:
+// Michael Riffle <mriffle@uw.edu>
+//
+
+// params will need changed per workflow run
+params {
+    
+    pdc.study_id = 'PDC000504'
+    pdc.n_raw_files = 2
+
+	// options for msconvert
+    msconvert.do_demultiplex = false;          // whether or not to demultiplex with msconvert
+    msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+    
+    msconvert_only = true
+}
+
+// if running jobs locally change these to match system capabilities
+profiles {
+
+    // "standard" is the profile used when the steps of the workflow are run
+    // locally on your computer. These parameters should be changed to match
+    // your system resources (that you are willing to devote to running
+    // workflow jobs).
+    standard {
+        params.max_memory = '8.GB'
+        params.max_cpus = 4
+        params.max_time = '1.h'
+
+        params.mzml_cache_directory = './mzml_cache'
+        params.panorama_cache_directory = './raw_cache'
+    }
+}

--- a/workflows/get_input_files.nf
+++ b/workflows/get_input_files.nf
@@ -96,6 +96,8 @@ workflow get_input_files {
             } else {
                 replicate_metadata = params.replicate_metadata
             }
+        } else if(params.pdc.study_id != null) {
+            replicate_metadata = null
         } else {
             METADATA_PLACEHOLDER('EMPTY')
             replicate_metadata = METADATA_PLACEHOLDER.out


### PR DESCRIPTION
* Add GitHub action stub test for pulling raw files from the PDC
* Fix bug where PDC metadata would not be used to annotate skyline document.
* Add stub tests for `params.msconvert_only`
* Delete code that was duplicated during a git merge which was causing `msconvert_only` to fail.