### PR TITLE
Handle spcaes in raw/mzML file names

### DIFF
--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -49,11 +49,11 @@ process ENCYCLOPEDIA_SEARCH_FILE {
     stub:
     """
     touch stub.stderr stub.stdout
-    touch "${mzml_file}.elib"
+    touch ${mzml_file}.elib
     touch "${mzml_file.baseName}.dia"
-    touch "${mzml_file}.features.txt"
-    touch "${mzml_file}.encyclopedia.txt"
-    touch "${mzml_file}.encyclopedia.decoy.txt"
+    touch ${mzml_file}.features.txt
+    touch ${mzml_file}.encyclopedia.txt
+    touch ${mzml_file}.encyclopedia.decoy.txt
 
     md5sum *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
     stat -L --printf='%n\t%s\n' *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sort > sizes.txt

--- a/modules/msconvert.nf
+++ b/modules/msconvert.nf
@@ -32,6 +32,6 @@ process MSCONVERT {
 
     stub:
     """
-    touch ${raw_file.baseName}.mzML
+    touch '${raw_file.baseName}.mzML'
     """
 }

--- a/modules/panorama.nf
+++ b/modules/panorama.nf
@@ -84,7 +84,7 @@ process PANORAMA_GET_MS_FILE_LIST {
         > >(tee "panorama-get-files.stdout") 2> >(tee "panorama-get-files.stderr" >&2) && \
 
     # Filter raw files by file_glob and prepend web_dav_url to file names
-    grep -P '${regex}' all_files.txt | xargs printf '${web_dav_url.replaceAll("%", "%%")}/%s\n' > download_files.txt
+    grep -P '${regex}' all_files.txt | xargs -d'\\n' printf '${web_dav_url.replaceAll("%", "%%")}/%s\\n' > download_files.txt
     """
 }
 

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -112,7 +112,7 @@ process SKYLINE_IMPORT_MZML {
     wine SkylineCmd \
         --in="${skyline_zipfile.baseName}" --memstamp \
         --import-no-join \
-        --import-file="/tmp/${mzml_file}" \
+        --import-file="/tmp/${mzml_file.name}" \
         > >(tee '${mzml_file.baseName}.stdout') 2> >(tee '${mzml_file.baseName}.stderr' >&2)
     """
 
@@ -142,7 +142,8 @@ process SKYLINE_MERGE_RESULTS {
         path('output_file_hashes.txt'), emit: output_file_hashes
 
     script:
-    import_files_params = "--import-file=${(mzml_files as List).collect{ "/tmp/" + file(it).name }.join(' --import-file=')}"
+
+    import_files_params = "--import-file=\"${(mzml_files as List).collect{ "/tmp/" + file(it).name }.join('\" --import-file=\"')}\""
     protein_parsimony_args = "--import-fasta=${fasta} --associate-proteins-shared-peptides=DuplicatedBetweenProteins --associate-proteins-min-peptides=1 --associate-proteins-remove-subsets --associate-proteins-minimal-protein-list"
     if(params.skyline.group_by_gene) {
         protein_parsimony_args += ' --associate-proteins-gene-level-parsimony'

--- a/workflows/get_mzmls.nf
+++ b/workflows/get_mzmls.nf
@@ -54,7 +54,7 @@ workflow get_mzmls {
             // Check that we have exactly 1 MS file extension
             directories = spectra_dirs.collect{ it -> "${it}${it[-1] == '/' ? '' : '/' }${spectra_glob}" }.join('\n')
             if (extensions.size() == 0) {
-                error "No files matches fore:\n" + directories +
+                error "No files matches for:\n" + directories +
                       "\nPlease choose a file glob that will match raw or mzML files."
             }
             if (extensions.size() > 1) {

--- a/workflows/get_mzmls.nf
+++ b/workflows/get_mzmls.nf
@@ -52,7 +52,7 @@ workflow get_mzmls {
             extensions = fileList.collect { it.substring(it.lastIndexOf('.') + 1) }.unique()
 
             // Check that we have exactly 1 MS file extension
-            directories = spectra_dir.collect{ it -> "${it}${it[-1] == '/' ? '' : '/' }${spectra_glob}" }.join('\n')
+            directories = spectra_dirs.collect{ it -> "${it}${it[-1] == '/' ? '' : '/' }${spectra_glob}" }.join('\n')
             if (extensions.size() == 0) {
                 error "No files matches fore:\n" + directories +
                       "\nPlease choose a file glob that will match raw or mzML files."


### PR DESCRIPTION
* Make sure we are able to handle `mzML` and `raw` files with spaces or other crazy characters in the file name
* Fix a small bug in `workflows/get_mzmls.nf` where error messages weren't being printed properly in some cases