### PR TITLE
Explicitly specify aws cli output format.

### DIFF
--- a/modules/aws.nf
+++ b/modules/aws.nf
@@ -23,7 +23,7 @@ process GET_AWS_USER_ID {
 
     script:
     """
-    aws sts get-caller-identity | grep '"Arn"' | sed 's/.*user\\///' | tr -d '",' | tr -d '\n'
+    aws sts get-caller-identity --output text --query Arn | sed 's/.*user\\///' | tr -d '\n'
     """
 
     stub:


### PR DESCRIPTION
I ran into an issue after configuring aws credentials where I had set the default output format to `text` which broke the `GET_AWS_USER_ID` process which expects the output to be `json`. I fixed the command to explicitly ask for text output so there won't be quotes in the output.

This probably should also be updated on any workflow that uses the `GET_AWS_USER_ID` process.