### PR TITLE
Add m/z shift option

### DIFF
--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -102,6 +102,9 @@ The ``params`` Section
      - ``msconvert.do_simasspectra``
      - If starting with raw files, this is the value used by ``msconvert`` for the ``do_simasspectra`` parameter. Default: ``true``.
    * -
+     - ``msconvert.mz_shift_ppm``
+     - If starting with raw files, ``msconvert`` will shift all mz values by ``n`` ppm when converting to ``mzML``. If ``null`` the mz values are not shifed. Default: ``null``.
+   * -
      - ``encyclopedia.chromatogram.params``
      - If you are generating a chromatogram library for quantification, this is the command line options passed to EncyclopeDIA during the chromatogram generation step. Default: ``'-enableAdvancedOptions -v2scoring'`` If you do not wish to pass any options to EncyclopeDIA, this must be set to ``''``.
    * -

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -304,7 +304,7 @@ process SKYLINE_RUN_REPORTS {
 
     for skyrfile in ./*.skyr; do
         # Add report to document
-        echo "--report-add=\\"${skyrfile}\\"" >> export_reports.bat
+        echo "--report-add=\\"${skyrfile}\\" --report-conflict-resolution=overwrite" >> export_reports.bat
 
         # Export report
         awk -F'"' '/<view name=/ { print $2 }' "$skyrfile" | while read reportname; do

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,8 +57,10 @@ params {
     email = null                    // email to notify of workflow outcome, leave null to send no email
     skyline.template_file = null    // the skyline template, if null use default_skyline_template_file
     panorama_upload = false;        // whether or not to upload the results to PanoramaWeb
+
     msconvert.do_demultiplex = true;          // whether or not to demultiplex with msconvert
     msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+    msconvert.mz_shift_ppm = null             // shift all mz values by n ppn.
 
     // If set to true, only run msconvert and stop. Resulting mzML files will be saved to the
     // "msconvert" subdirectory of the results directory.

--- a/resources/pipeline.config
+++ b/resources/pipeline.config
@@ -45,6 +45,7 @@ params {
 	// options for msconvert
     msconvert.do_demultiplex = true;          // whether or not to demultiplex with msconvert
     msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+    msconvert.mz_shift_ppm = null             // shift all mz values by n ppn.
 
     // default parameters for Encyclopedia searches, can be overridden
     encyclopedia.chromatogram.params    = '-enableAdvancedOptions -v2scoring'

--- a/workflows/get_mzmls.nf
+++ b/workflows/get_mzmls.nf
@@ -80,9 +80,7 @@ workflow get_mzmls {
             }.set{ms_file_ch}
 
         // Convert raw files if applicable
-        MSCONVERT(ms_file_ch.raw,
-                  params.msconvert.do_demultiplex,
-                  params.msconvert.do_simasspectra)
+        MSCONVERT(ms_file_ch.raw)
 
         mzml_ch = MSCONVERT.out.concat(ms_file_ch.mzml)
 }

--- a/workflows/get_pdc_files.nf
+++ b/workflows/get_pdc_files.nf
@@ -42,9 +42,7 @@ workflow get_pdc_files {
             | map{row -> tuple(row.url, row.file_name, row.md5sum)} \
             | GET_FILE
 
-        MSCONVERT(GET_FILE.out.downloaded_file,
-                  params.msconvert.do_demultiplex,
-                  params.msconvert.do_simasspectra)
+        MSCONVERT(GET_FILE.out.downloaded_file)
 
         wide_mzml_ch = MSCONVERT.out.mzml_file
 }


### PR DESCRIPTION
## New `params.msconvert.mz_shift_ppm` option
* Add an option in `MSCONVERT` to shift all m/z values in `mzML` file by by `n` ppm. This is a useful option if the mass calibration of the files have to be adjusted.
* Because there is an additional msconvert parameter the path of the `storeDir` was also adjusted to avoid collisions between different combinations of parameters.
* Instead of using a new sub-directory for each parameter the `storeDir` path is now based off a hash combining the string of the msconvert command and the proteowizard docker container. There will be a unique `storeDir` path for each combination of msconvert parameters and versions of the proteowizard docker container.

## Bug fix
* Add a flag in `SKYLINE_RUN_REPORTS` to override existing reports in the template document if they conflict with the names of new reports being added in the `.skyr` file. Without the `--report-conflict-resolution=overwrite` option, if someone were using a custom template document and the report names conflict they will get an error.