### PR TITLE
Update qc_pipeline container.

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:0.15',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.2.5',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.3.1',
         proteowizard:          'quay.io/protio/pwiz-skyline-i-agree-to-the-vendor-licenses:3.0.24172-63d00b1'
     ]
 }


### PR DESCRIPTION
- Update qc_pipeline from `2.2.5 -> 2.3.1`
- This update will add interactive PCA plots in the QC report.