### PR TITLE
Publish pdf and html batch reports

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.2.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.4.2',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.4.3',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -186,8 +186,11 @@ process GENERATE_BATCH_REPORT {
         > >(tee "generate_batch_rmd.stdout") 2> >(tee "generate_batch_rmd.stderr" >&2)
 
         mkdir plots
-        Rscript -e "rmarkdown::render('bc_report.rmd')" \
-            > >(tee -a "render_batch_rmd.stdout") 2> >(tee -a "render_batch_rmd.stderr" >&2)
+        Rscript -e "rmarkdown::render('bc_report.rmd', output_format=c('html_document'))" \
+            > >(tee -a "render_batch_rmd_html.stdout") 2> >(tee -a "render_batch_rmd_html.stderr" >&2)
+
+        Rscript -e "rmarkdown::render('bc_report.rmd', output_format=c('pdf_document'), params=list(save_plots=FALSE, write_tables=FALSE))" \
+            > >(tee -a "render_batch_rmd_html.stdout") 2> >(tee -a "render_batch_rmd_html.stderr" >&2)
         """
 
     stub:

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -153,10 +153,12 @@ process GENERATE_QC_QMD {
 
 process GENERATE_BATCH_REPORT {
     publishDir params.output_directories.batch_report, pattern: '*.rmd', failOnError: true, mode: 'copy'
+    publishDir params.output_directories.batch_report, pattern: '*.{pdf,html}', failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report_tables, pattern: '*.tsv', failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report_plots, pattern: "plots/*.${params.batch_report.plot_ext}", failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report, pattern: '*.std{err,out}', failOnError: true, mode: 'copy'
     label 'process_high_memory'
+    label 'run_as_root'
     container params.images.qc_pipeline
 
     input:
@@ -165,6 +167,7 @@ process GENERATE_BATCH_REPORT {
     output:
         path("bc_report.rmd"), emit: bc_rmd
         path("bc_report.html"), emit: bc_html
+        path("bc_report.pdf"), emit: bc_pdf
         path("*.tsv"), emit: tsv_reports, optional: true
         path("plots/*"), emit: bc_plots, optional: true
         path("*.stdout"), emit: stdout
@@ -190,7 +193,7 @@ process GENERATE_BATCH_REPORT {
             > >(tee -a "render_batch_rmd_html.stdout") 2> >(tee -a "render_batch_rmd_html.stderr" >&2)
 
         Rscript -e "rmarkdown::render('bc_report.rmd', output_format=c('pdf_document'), params=list(save_plots=FALSE, write_tables=FALSE))" \
-            > >(tee -a "render_batch_rmd_html.stdout") 2> >(tee -a "render_batch_rmd_html.stderr" >&2)
+            > >(tee -a "render_batch_rmd_pdf.stdout") 2> >(tee -a "render_batch_rmd_pdf.stderr" >&2)
         """
 
     stub:


### PR DESCRIPTION
## Fixes to batch report
- Update `qc_pipeline` container so both html and pdf batch reports are generated
- Fix `publishDir` directive in `GENERATE_BATCH_REPORT` so rendered reports are published to results directory