### PR TITLE
Bug fixes and stability improvements

### DIFF
--- a/modules/cascadia.nf
+++ b/modules/cascadia.nf
@@ -41,7 +41,7 @@ process CASCADIA_SEARCH {
 
         md5sum '${ms_file.join('\' \'')}' ${ms_file.baseName}.ssl | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' '${ms_file.join('\' \'')}' ${ms_file.baseName}.ssl | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats_${ms_file.baseName}.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats_${ms_file.baseName}.txt
         """
 
     stub:
@@ -52,7 +52,7 @@ process CASCADIA_SEARCH {
 
         md5sum '${ms_file.join('\' \'')}' "${ms_file.baseName}.ssl" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' '${ms_file.join('\' \'')}' "${ms_file.baseName}.ssl" | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats_${ms_file.baseName}.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats_${ms_file.baseName}.txt
         """
 }
 
@@ -81,7 +81,7 @@ process CASCADIA_FIX_SCAN_NUMBERS {
 
         md5sum ${ms_file} ${ssl_file} ${ssl_file.baseName}.fixed.ssl | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' ${ms_file} ${ssl_file} ${ssl_file.baseName}.fixed.ssl | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 
     stub:
@@ -91,7 +91,7 @@ process CASCADIA_FIX_SCAN_NUMBERS {
 
         md5sum ${ms_file} ${ssl_file} "${ssl_file.baseName}.fixed.ssl" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' ${ms_file} ${ssl_file} "${ssl_file.baseName}.fixed.ssl" | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 }
 
@@ -120,7 +120,7 @@ process CASCADIA_CREATE_FASTA {
 
         md5sum ${ssl_file} ${ssl_file.baseName}.fasta | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' ${ssl_file} ${ssl_file.baseName}.fasta | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 
     stub:
@@ -130,7 +130,7 @@ process CASCADIA_CREATE_FASTA {
 
         md5sum "${ssl_file.baseName}.fasta" | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' "${ssl_file.baseName}.fasta" | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 }
 
@@ -153,7 +153,7 @@ process CASCADIA_COMBINE_SSL_FILES {
 
         md5sum '${ssl_files.join('\' \'')}' combined.ssl | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' '${ssl_files.join('\' \'')}' combined.ssl | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 
     stub:
@@ -162,7 +162,7 @@ process CASCADIA_COMBINE_SSL_FILES {
 
         md5sum '${ssl_files.join('\' \'')}' combined.ssl | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
         stat -L --printf='%n\t%s\n' '${ssl_files.join('\' \'')}' combined.ssl | sort > sizes.txt
-        join -t'\t' hashes.txt sizes.txt > output_file_stats.txt
+        join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
         """
 }
 

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -31,7 +31,7 @@ printf "%s\\n" "\${stat_files[@]}" | while IFS= read -r file; do
     stat -L --printf='%n\\t%s\\n' "\$file"
 done | sort > sizes.txt
 
-join -t\\t hashes.txt sizes.txt > output_file_stats.txt
+join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
     """
     return command
 }

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -295,7 +295,7 @@ process DIANN_MBR {
 
 process BLIB_BUILD_LIBRARY {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
-    label 'process_medium'
+    label 'process_high_memory'
     label 'proteowizard'
     container params.images.proteowizard
 

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -43,7 +43,7 @@ process ENCYCLOPEDIA_SEARCH_FILE {
 
     md5sum *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
     stat -L --printf='%n\\t%s\\n' *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sort > sizes.txt
-    join -t'\\t' hashes.txt sizes.txt > output_file_stats.txt
+    join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
     """
 
     stub:
@@ -57,7 +57,7 @@ process ENCYCLOPEDIA_SEARCH_FILE {
 
     md5sum *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sed -E 's/([a-f0-9]{32}) [ \\*](.*)/\\2\\t\\1/' | sort > hashes.txt
     stat -L --printf='%n\\t%s\\n' *.elib *.features.txt *.encyclopedia.txt *.encyclopedia.decoy.txt *.mzML | sort > sizes.txt
-    join -t'\\t' hashes.txt sizes.txt > output_file_stats.txt
+    join -t\$'\\t' hashes.txt sizes.txt > output_file_stats.txt
     """
 }
 

--- a/modules/file_stats.nf
+++ b/modules/file_stats.nf
@@ -7,11 +7,11 @@ process CALCULATE_MD5 {
         path(file_to_check)
 
     output:
-        tuple val("${file_to_check.name}"), env("md5_sum")
+        path('hash.txt')
 
     script:
         """
-        md5_sum=\$( md5sum ${file_to_check} |awk '{print \$1}' )
+        md5sum ${file_to_check} > 'hash.txt'
         """
 }
 

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -198,7 +198,7 @@ process GENERATE_BATCH_REPORT {
 
     stub:
         """
-        touch bc_report.rmd bc_report.html
+        touch bc_report.rmd bc_report.html bc_report.pdf
         touch generate_batch_rmd.stdout generate_batch_rmd.stderr
         """
 }

--- a/subworkflows/combine_file_hashes.nf
+++ b/subworkflows/combine_file_hashes.nf
@@ -72,11 +72,16 @@ workflow combine_file_hashes {
         md5_input = file_stat_files.map{ it -> it[1] }
         CALCULATE_MD5(md5_input)
 
+        calc_md5_hashes = CALCULATE_MD5.out
+            .splitText()
+            .map{ it -> tuple(it.split(/\s+/)) }
+            .map{ it -> tuple(it[1], it[0]) }
+
         // Combine all file hashes into a single channel
         output_file_hash_ch = search_file_data.mzml_files
             .concat(
                 file_stat_files
-                    .join(CALCULATE_MD5.out, failOnMismatch: true, failOnDuplicate: true)
+                    .join(calc_md5_hashes, failOnMismatch: true, failOnDuplicate: true)
                     .map{ it -> tuple(it[0], it[2], it[4], it[3]) }
             )
             .concat(search_file_data.search_files, skyline_doc_data)

--- a/subworkflows/get_pdc_files.nf
+++ b/subworkflows/get_pdc_files.nf
@@ -30,13 +30,21 @@ workflow get_pdc_files {
         get_pdc_study_metadata()
         metadata = get_pdc_study_metadata.out.metadata
 
-        metadata \
-            | splitJson() \
-            | map{ row -> tuple(row['url'], row['file_name'], row['md5sum'], row['file_size']) } \
-            | GET_FILE
+		if(params.pdc.s3_download) {
+            metadata
+                .splitJson()
+                .map{ row -> file(row['url']) }
+                .set{ all_paths_ch }
+        } else {
+            metadata
+                .splitJson()
+                .map{ row -> tuple(row['url'], row['file_name'], row['md5sum'], row['file_size']) } \
+                | GET_FILE
 
-        GET_FILE.out.downloaded_file
-            .tap{ all_paths_ch }
+            all_paths_ch = GET_FILE.out.downloaded_file
+        }
+
+        all_paths_ch
             .map{ file -> [null, file] }
             .branch{
                 raw:   it[1].name.endsWith('.raw')


### PR DESCRIPTION
* Increase RAM for `BLIB_BUILD_LIBRARY`
* Use a more reliable method for specifying field separator 
    - Depending on the version of `join` that is installed on a linux distro the field separator argument will be interpreted differently. Specifying it as `-t$'\t'` ensures that the escape character is interpreted correctly in all versions.
* Fix the fix failing stub for `GENERATE_BATCH_REPORT`
* Write md5 hash in `CALCULATE_MD5` process to file instead of environment variable
    - Reading process output from environment variables is broken on some older nextflow versions on the AWS executor.
* Use s3 file paths directly when `params.pdc.s3_download == true` instead of running `GET_FILE` process