### PR TITLE
Bug fixes for skipping DIA search

### DIFF
--- a/test-resources/test-skip-dia-search.config
+++ b/test-resources/test-skip-dia-search.config
@@ -1,0 +1,64 @@
+
+params {
+
+    // the search engine to use
+    search_engine = null
+
+	// the data to be quantified (e.g., wide window data)
+    quant_spectra_dir = ['Plate1': 'test-resources/narrow-window',
+                         'Plate2': 'test-resources/wide-window']
+
+	// which files in this directory to use, default: all raw files
+	quant_spectra_glob = '*.raw'
+
+    fasta = 'test-resources/test.fasta'
+    spectral_library = 'test-resources/test.dlib'
+
+	// options for msconvert
+    msconvert.do_demultiplex = true;          // whether or not to demultiplex with msconvert
+    msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
+
+    // default parameters for Encyclopedia searches, can be overridden
+    encyclopedia.chromatogram.params    = '-enableAdvancedOptions -v2scoring'
+    encyclopedia.quant.params           = '-enableAdvancedOptions -v2scoring'
+
+    encyclopedia.save_output            = false
+
+    replicate_metadata = null
+    skyline.skip = false
+
+    qc_report.skip = false
+    qc_report.standard_proteins = null
+    qc_report.color_vars = null
+    qc_report.export_tables = false
+}
+
+// if running jobs locally change these to match system capabilities
+profiles {
+
+    // "standard" is the profile used when the steps of the workflow are run
+    // locally on your computer. These parameters should be changed to match
+    // your system resources (that you are willing to devote to running
+    // workflow jobs).
+    standard {
+        params.max_memory = '8.GB'
+        params.max_cpus = 4
+        params.max_time = '1.h'
+
+        params.mzml_cache_directory = './mzml_cache'
+        params.panorama_cache_directory = './raw_cache'
+    }
+}
+
+// advanced config: change settings to match your email provider to send emails
+mail {
+    from = 'address@host.com'
+    smtp.host = 'smtp.host.com'
+    smtp.port = 587
+    smtp.user = 'smpt_user'
+    smtp.password = 'smtp_password'
+    smtp.auth = true
+    smtp.starttls.enable = true
+    smtp.starttls.required = false
+    mail.smtp.ssl.protocols = 'TLSv1.2'
+}

--- a/workflows/carafe.nf
+++ b/workflows/carafe.nf
@@ -84,11 +84,12 @@ workflow carafe {
             carafe_psm_file = DIANN_SEARCH.out.precursor_report
         }
 
+        search_engine = params.search_engine == null ? 'diann' : params.search_engine.toLowerCase()
         run_carafe(spectra_file,
                    carafe_fasta,
                    carafe_psm_file,
                    params.carafe.cli_options,
-                   params.search_engine)
+                   search_engine)
 
         // We need to make sure speclib_tsv is a value channel
         // because Nextflow thinks it should be a queue channel

--- a/workflows/dia_search.nf
+++ b/workflows/dia_search.nf
@@ -31,11 +31,18 @@ workflow dia_search{
 
         if(search_engine == null) {
 
+            if (params.skyline.skip == true) {
+                error "Cannot skip DIA search when params.skyline.skip is true!"
+            }
+            spectral_library.ifEmpty {
+                error "Spectral library is not defined!"
+            }
+
             search_engine_version = Channel.empty()
             search_file_stats = Channel.empty()
             final_speclib = spectral_library
             all_search_file_ch = Channel.empty()
-            search_fasta = Channel.empty()
+            search_fasta = fasta
 
         } else if(search_engine.toLowerCase() == 'encyclopedia') {
 


### PR DESCRIPTION
* Add GitHub action test for skipping DIA search and generating skyline document directly from `params.spectral_library`
* Catch invalid combination of `params.skyline.skip = true` and `params.search_engine = null`