### PR TITLE
Improvements to process resource requests and error checking

### DIFF
--- a/.github/workflows/push-stub-run.yml
+++ b/.github/workflows/push-stub-run.yml
@@ -17,10 +17,11 @@ jobs:
           'test-encyclopedia-narrow-gpf.config',
           'test-encyclopedia-wide-only.config',
           'test-diann-pdc.config',
+          'test-skip-dia-search.config',
           'test-msconvert-only-pdc.config',
           'test-msconvert-only-local.config'
         ]
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,9 +1,10 @@
 
 process {
-    // TODO nf-core: Check the defaults for all processes
-    cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
-    memory = { check_max( 4.GB * task.attempt, 'memory' ) }
-    time   = { check_max( 1.h  * task.attempt, 'time'   ) }
+    resourceLimits = [cpus: params.max_cpus, memory: params.max_memory, time: params.max_time]
+
+    cpus   = 1
+    memory = 4.GB
+    time   = 1.h
 
     errorStrategy = { task.exitStatus in [143,137,104,134,139,5,6,null] ? 'retry' : 'finish' }
     maxRetries    = 3
@@ -19,36 +20,36 @@ process {
     // TODO nf-core: Customise requirements for specific processes.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_low_constant {
-        cpus   = { check_max( 2, 'cpus'      ) }
-        memory = { check_max( 8.GB, 'memory' ) }
-        time   = { check_max( 1.h, 'time'    ) }
+        cpus   = 2
+        memory = 8.GB
+        time   = 1.h
     }
     withLabel:process_low {
-        cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 8.GB  * task.attempt, 'memory'  ) }
-        time   = { check_max( 2.h   * task.attempt, 'time'    ) }
+        cpus   = { 2     * task.attempt }
+        memory = { 8.GB  * task.attempt }
+        time   = { 2.h   * task.attempt }
     }
     withLabel:process_medium {
-        cpus   = { check_max( 4     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 15.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+        cpus   = { 4     * task.attempt }
+        memory = { 15.GB * task.attempt }
+        time   = { 8.h   * task.attempt }
     }
     withLabel:process_high {
-        cpus   = { check_max( 32    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 60.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+        cpus   = { 32    * task.attempt }
+        memory = { 60.GB * task.attempt }
+        time   = { 8.h   * task.attempt }
     }
     withLabel:process_long {
-        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
+        time   = { 20.h  * task.attempt }
     }
     withLabel:process_short {
-        time   = { check_max( 1.h  * task.attempt, 'time'    ) }
+        time   = { 1.h  * task.attempt }
     }
     withLabel:process_twohours {
-        time   = { check_max( 2.h  * task.attempt, 'time'    ) }
+        time   = { 2.h  * task.attempt }
     }
     withLabel:process_high_memory {
-        memory = { check_max( 60.GB * task.attempt, 'memory'  ) }
+        memory = { 60.GB * task.attempt }
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'
@@ -60,14 +61,14 @@ process {
 
     // labels added for TEI-REX workflows
     withLabel:process_high_constant {
-        cpus   = { check_max( 128, 'cpus'      ) }
-        memory = { check_max( 128.GB, 'memory' ) }
-        time   = { check_max( 24.h, 'time'    ) }
+        cpus   = 128
+        memory = 128.GB
+        time   = 24.h
     }
     withLabel:process_memory_high_constant {
-        cpus   = { check_max( 16, 'cpus'      ) }
-        memory = { check_max( 128.GB, 'memory' ) }
-        time   = { check_max( 24.h, 'time'    ) }
+        cpus   = 16
+        memory = 128.GB
+        time   = 24.h
     }
     withLabel:proteowizard {
         containerOptions = { workflow.profile == 'standard' ? '-e LOCAL_USER_ID="$(id -u)" -e LOCAL_GROUP_ID="$(id -g)"' : '' }

--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.2.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.4.3',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.5.0',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.2.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.5.0',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.5.1',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.2.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.5.1',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.5.2',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -67,7 +67,11 @@ The ``params`` Section
      - The path to the directory containing the raw data to be quantified. If using narrow window DIA and GPF to generated a chromatogram library this is the location of the wide-window data to be searched using the chromatogram library.
    * -
      - ``quant_spectra_glob``
-     - Which files in this directory to use. Default: ``*.raw``
+     - Which files in this directory to use.
+       Must be ``null`` if ``quant_spectra_regex`` is set. Default: ``*.raw``
+   * - ``quant_spectra_regex``
+     - Use this regex instead of ``quant_spectra_glob`` to select files in ``quant_spectra_dir``.
+       If set, ``quant_spectra_glob`` must be set to ``null``. Default: ``null``.
    * -
      - ``files_per_quant_batch``
      - Randomly select ``n`` files per batch in ``quant_spectra_dir``. If ``null`` all the files in ``quant_spectra_dir`` are used. Default is ``null``.
@@ -76,7 +80,11 @@ The ``params`` Section
      - If you are creating a chromatogram library using GPF and narrow window DIA, this is the path to the directory containing the narrow-window raw data.
    * -
      - ``chromatogram_library_spectra_glob``
-     - Which files in this directory to use. Default: ``*.raw``
+     - Which files in this directory to use.
+       Must be ``null`` if ``chromatogram_library_spectra_regex`` is set. Default: ``*.raw``
+   * - ``chromatogram_library_spectra_regex``
+     - Use this regex instead of ``chromatogram_library_spectra_glob`` to select files in ``chromatogram_library_spectra_dir``.
+       If set, ``chromatogram_library_spectra_glob`` must be set to ``null``. Default: ``null``.
    * -
      - ``use_vendor_raw``
      - If supported by the ``search_engine``, skip the ``MSCONVERT`` step to generate mzMLs and use vendor raw files for the search and to generate the Skyline document.

--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -428,6 +428,7 @@ The ``process`` Section
 
 In Nextflow process labels can be used to adjust the compute resources that are allocated to a given process.
 By default these processes will dynamically adjust the requested memory and run time to fit the number and size of the files being processed.
+Nextflow will try to allocate resources using the formulas below up to the maximum values specified by ``params.max_memory``, ``params.max_time`` and ``params.max_cpus``.
 
 .. list-table:: Default resources for processes with custom labels
    :widths: 15 5 50 30
@@ -455,7 +456,7 @@ By default these processes will dynamically adjust the requested memory and run 
      - 4 hours
    * - ``ENCYCLOPEDIA_CREATE_ELIB``
      - 32
-     - Maximum of 32 GB and 4 times the number of individual MS files
+     - Maximum of 32 GB and 4 times the number of MS files
      - 24 hours
    * - ``SKYLINE_ADD_LIB``
      - 4
@@ -463,23 +464,23 @@ By default these processes will dynamically adjust the requested memory and run 
      - 2 hours
    * - ``SKYLINE_IMPORT_MS_FILE``
      - 8
-     - Maximum of 8 GB and the sum of the MS file and skyline template with spectral library.
+     - Maximum of 8 GB and the sum of the MS file and skyline template with spectral library
      - 2 hours
    * - ``SKYLINE_MERGE_RESULTS``
      - 32
-     - Maximum of 8 GB and 1.5 times the size of all .skyd files
+     - Maximum of 8 GB and 1.5 times the sum of the sizes of the .skyd files
      - 8 hours
    * - ``SKYLINE_ANNOTATE_DOCUMENT``
      - 8
-     - Maximum of 8 GB and 1.5 time the size of the skyline zip file
+     - Maximum of 8 GB and 1.5 times the size of the skyline zip file
      - 4 hours
    * - ``SKYLINE_RUN_REPORTS``
      - 8
-     - Maximum of 8 GB and 1.5 time the size of the skyline zip file
+     - Maximum of 8 GB and 1.5 times the size of the skyline zip file
      - 4 hours
    * - ``MERGE_REPORTS``
      - 2
-     - Maximum of 8 GB and the sum of the sizes of the precursor reports.
+     - Maximum of 8 GB and the sum of the sizes of the precursor reports
      - 8 hours
    * - ``FILTER_IMPUTE_NORMALIZE``
      - 8
@@ -488,7 +489,7 @@ By default these processes will dynamically adjust the requested memory and run 
    * - ``GENERATE_QC_QMD``
      - 2
      - Maximum of 8 GB and 2 times the size of the batch database
-     - 1 hour
+     - 2 hours
    * - ``GENERATE_BATCH_REPORT``
      - 2
      - Maximum of 8 GB and 2 times the size of the batch database

--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -67,9 +67,9 @@ The ``params`` Section
      - The path to the directory containing the raw data to be quantified. If using narrow window DIA and GPF to generated a chromatogram library this is the location of the wide-window data to be searched using the chromatogram library.
    * -
      - ``quant_spectra_glob``
-     - Which files in this directory to use.
-       Must be ``null`` if ``quant_spectra_regex`` is set. Default: ``*.raw``
-   * - ``quant_spectra_regex``
+     - Which files in this directory to use. Default: ``*.raw``
+   * -
+     - ``quant_spectra_regex``
      - Use this regex instead of ``quant_spectra_glob`` to select files in ``quant_spectra_dir``.
        If set, ``quant_spectra_glob`` must be set to ``null``. Default: ``null``.
    * -
@@ -80,9 +80,9 @@ The ``params`` Section
      - If you are creating a chromatogram library using GPF and narrow window DIA, this is the path to the directory containing the narrow-window raw data.
    * -
      - ``chromatogram_library_spectra_glob``
-     - Which files in this directory to use.
-       Must be ``null`` if ``chromatogram_library_spectra_regex`` is set. Default: ``*.raw``
-   * - ``chromatogram_library_spectra_regex``
+     - Which files in this directory to use. Default: ``*.raw``
+   * -
+     - ``chromatogram_library_spectra_regex``
      - Use this regex instead of ``chromatogram_library_spectra_glob`` to select files in ``chromatogram_library_spectra_dir``.
        If set, ``chromatogram_library_spectra_glob`` must be set to ``null``. Default: ``null``.
    * -
@@ -128,7 +128,7 @@ The ``params`` Section
      - Additional command line arguments passed to ``PDC_client``. Default is ``null``.
    * - ``pdc.s3_download``
      - If set to ``true`` download raw files through an S3 transfer instead of over https.
-       This option will only work if the workflow execution enviroment is configured to directly access PDC AWS infrastructure.
+       This option will only work if the workflow execution environment is configured to directly access PDC AWS infrastructure.
        Default is ``faise``.
 
 
@@ -148,7 +148,8 @@ The ``params`` Section
    * - ``carafe.carafe_fasta``
      - FASTA file used by Carafe to generate final spectral library. If ``null``, ``params.fasta`` is used.
    * - ``carafe_cli_options``
-     - Command line options to pass to Carafe. Note: Do not set the ``se``, ``lf_type``, ``-db``, ``-i``, ``-o`` parameters, these are handled by the workflow. The default is to not pass any command line option and use Carafe's defaults, see https://github.com/Noble-Lab/Carafe for more details.
+     - Command line options to pass to Carafe. Note: Do not set the ``se``, ``lf_type``, ``-db``, ``-i``, ``-o`` parameters, these are handled by the workflow. The default is ``-min_pep_charge 2 -max_pep_charge 3``
+       See the `Carafe GitHub page <https://github.com/Noble-Lab/Carafe>`_ for details on available parameters.
    * - ``carafe.diann_fasta``
      - The FASTA file used by the DIA-NN search in the Carafe subworkflow. If not set either ``params.carafe_fasta`` or ``params.fasta`` will be used. Default: ``null``.
 
@@ -420,6 +421,117 @@ These parameters describe the capability of your local computer for running the 
    * - ✓
      - ``params.panorama_cache_directory``
      - If the RAW files to be processed are in PanoramaWeb, the RAW files will be downloaded to and cached in this directory for future use.
+
+
+The ``process`` Section
+^^^^^^^^^^^^^^^^^^^^^^^
+
+In Nextflow process labels can be used to adjust the compute resources that are allocated to a given process.
+By default these processes will dynamically adjust the requested memory and run time to fit the number and size of the files being processed.
+
+.. list-table:: Default resources for processes with custom labels
+   :widths: 15 5 50 30
+   :header-rows: 1
+
+   * - Process
+     - CPUs
+     - Memory
+     - Walltime
+   * - ``DIANN_QUANT``
+     - 8
+     - Maximum of 8 GB and 1.5 times the sum of the sizes of the MS and spectral library files
+     - 2 hours
+   * - ``DIANN_MBR``
+     - 32
+     - Maximum of 16 GB and 1.5 times the sum of the MS file sizes
+     - 10 minutes times the number of MS files
+   * - ``BLIB_BUILD_LIBRARY``
+     - 2
+     - Maximum of 8 GB and 1.5 times the size of the precursor report file
+     - 2 hours
+   * - ``ENCYCLOPEDIA_SEARCH_FILE``
+     - 8
+     - 16 GB
+     - 4 hours
+   * - ``ENCYCLOPEDIA_CREATE_ELIB``
+     - 32
+     - Maximum of 32 GB and 4 times the number of individual MS files
+     - 24 hours
+   * - ``SKYLINE_ADD_LIB``
+     - 4
+     - Maximum of 8 GB and 1.5 times the spectral library size
+     - 2 hours
+   * - ``SKYLINE_IMPORT_MS_FILE``
+     - 8
+     - Maximum of 8 GB and the sum of the MS file and skyline template with spectral library.
+     - 2 hours
+   * - ``SKYLINE_MERGE_RESULTS``
+     - 32
+     - Maximum of 8 GB and 1.5 times the size of all .skyd files
+     - 8 hours
+   * - ``SKYLINE_ANNOTATE_DOCUMENT``
+     - 8
+     - Maximum of 8 GB and 1.5 time the size of the skyline zip file
+     - 4 hours
+   * - ``SKYLINE_RUN_REPORTS``
+     - 8
+     - Maximum of 8 GB and 1.5 time the size of the skyline zip file
+     - 4 hours
+   * - ``MERGE_REPORTS``
+     - 2
+     - Maximum of 8 GB and the sum of the sizes of the precursor reports.
+     - 8 hours
+   * - ``FILTER_IMPUTE_NORMALIZE``
+     - 8
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 4 hours
+   * - ``GENERATE_QC_QMD``
+     - 2
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 1 hour
+   * - ``GENERATE_BATCH_REPORT``
+     - 2
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 4 hours
+   * - ``EXPORT_TABLES``
+     - 2
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 2 hours
+   * - ``RENDER_QC_REPORT``
+     - 2
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 2 hours
+   * - ``EXPORT_GENE_REPORTS``
+     - 2
+     - Maximum of 8 GB and 2 times the size of the batch database
+     - 2 hours
+
+In most cases there is no need for users to adjust the default values.
+One application where adjusting these parameters could be useful is to select the AWS batch queue to be used for a specific process.
+The ``DIANN_MBR`` process downloads all MS files to a single EC2 instance.
+In cases where large numbers of files are being processed the available disk space on the default EC2 instance might not be sufficient to hold all the MS files.
+The ``DIANN_MBR`` process can be set to run in a queue with more disk space by adding the following to the pipeline config.
+
+.. code-block:: groovy
+
+    process {
+       withLabel:DIANN_MBR {
+           queue = "nextflow_basic_ec2_1tb"
+       }
+   }
+
+The resource requierments for each of the processes listed above can be fully customized by adding a ``withLabel`` block to the ``process`` section of the pipeline config file.
+For example, to use a constant memory and wall time request to ``DIANN_MBR`` you could add the following to the pipeline config file:
+
+.. code-block:: groovy
+
+    process {
+        withLabel:DIANN_MBR {
+            memory = 248.GB
+            time = 48.h
+        }
+    }
+
 
 The ``mail`` Section
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/workflow_parameters.rst
+++ b/docs/source/workflow_parameters.rst
@@ -439,11 +439,11 @@ By default these processes will dynamically adjust the requested memory and run 
      - Walltime
    * - ``DIANN_QUANT``
      - 8
-     - Maximum of 8 GB and 1.5 times the sum of the sizes of the MS and spectral library files
+     - Maximum of 16 GB and 2 times the sum of the sizes of the MS and spectral library files
      - 2 hours
    * - ``DIANN_MBR``
      - 32
-     - Maximum of 16 GB and 1.5 times the sum of the MS file sizes
+     - Maximum of 32 GB and 2 times the sum of the MS file sizes
      - 10 minutes times the number of MS files
    * - ``BLIB_BUILD_LIBRARY``
      - 2

--- a/main.nf
+++ b/main.nf
@@ -2,6 +2,9 @@
 
 nextflow.enable.dsl = 2
 
+// functions for parameter validation
+include { validateParameters; paramsSummaryLog } from 'plugin/nf-schema'
+
 // Sub workflows
 include { get_input_files } from "./subworkflows/get_input_files"
 include { get_ms_files as get_narrow_ms_files } from "./subworkflows/get_ms_files"
@@ -54,6 +57,9 @@ workflow {
 
     all_ms_file_ch = null       // hold all mzml files generated
     all_mzml_ch = null
+
+    // Validate input parameters
+    validateParameters()
 
     // version file channels
     search_engine_version = null

--- a/main.nf
+++ b/main.nf
@@ -110,10 +110,12 @@ workflow {
         String quant_spectra_regex = get_file_regex(
             params.quant_spectra_glob, params.quant_spectra_regex, 'quant_spectra'
         )
-        get_wide_ms_files(params.quant_spectra_dir,
-                          quant_spectra_regex,
-                          params.files_per_quant_batch,
-                          aws_secret_id)
+        get_wide_ms_files(
+            params.quant_spectra_dir,
+            quant_spectra_regex,
+            params.files_per_quant_batch,
+            aws_secret_id
+        )
         wide_ms_file_ch = get_wide_ms_files.out.ms_file_ch
         wide_mzml_ch = get_wide_ms_files.out.converted_mzml_ch
         quant_spectra_file_json = get_wide_ms_files.out.file_json
@@ -122,22 +124,24 @@ workflow {
     }
 
     narrow_ms_file_ch = null
-    chrom_lib_file_json = Channel.empty()
+    chrom_lib_file_json = null
     if(params.chromatogram_library_spectra_dir != null) {
         String chrom_lib_spectra_regex = get_file_regex(
             params.chromatogram_library_spectra_glob, params.chromatogram_library_spectra_regex,
             'chromatogram_library_spectra'
         )
-        get_narrow_ms_files(params.chromatogram_library_spectra_dir,
-                            chrom_lib_spectra_regex,
-                            params.files_per_chrom_lib,
-                            aws_secret_id)
-
+        get_narrow_ms_files(
+            params.chromatogram_library_spectra_dir,
+            chrom_lib_spectra_regex,
+            params.files_per_chrom_lib,
+            aws_secret_id
+        )
         narrow_ms_file_ch = get_narrow_ms_files.out.ms_file_ch
         chrom_lib_file_json = get_narrow_ms_files.out.file_json
         all_ms_file_ch = wide_ms_file_ch.concat(narrow_ms_file_ch).map{ it -> it[1] }
         all_mzml_ch = wide_mzml_ch.concat(get_narrow_ms_files.out.converted_mzml_ch)
     } else {
+        chrom_lib_file_json = Channel.value("[]")
         all_ms_file_ch = wide_ms_file_ch.map{ it -> it[1] }
         all_mzml_ch = wide_mzml_ch
     }

--- a/main.nf
+++ b/main.nf
@@ -24,7 +24,7 @@ include { GET_AWS_USER_ID } from "./modules/aws"
 include { BUILD_AWS_SECRETS } from "./modules/aws"
 
 // useful functions and variables
-include { param_to_list } from "./subworkflows/get_input_files"
+include { param_to_list } from "./modules/utils.nf"
 
 // Check if old Skyline parameter variables are defined.
 // If the old variable is defnied, return the params value of the old variable,

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 // functions for parameter validation
-include { validateParameters; paramsSummaryLog } from 'plugin/nf-schema'
+include { validateParameters } from 'plugin/nf-schema'
 
 // Sub workflows
 include { get_input_files } from "./subworkflows/get_input_files"

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -134,7 +134,7 @@ process DIANN_SEARCH {
 
 process CARAFE_DIANN_SEARCH {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
-    label 'process_high_constant'
+    label 'process_high'
     container params.images.diann
 
     input:
@@ -194,7 +194,10 @@ process CARAFE_DIANN_SEARCH {
 
 process DIANN_QUANT {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
-    label 'process_high'
+    cpus   8
+    memory { Math.max(8.0, ((ms_file.size() + spectral_library.size()) / (1024 ** 3)) * 1.5).GB }
+    time   { 2.h * task.attempt }
+    label 'DIANN_QUANT'
     container params.images.diann
     stageInMode { params.use_vendor_raw ? 'link' : 'symlink' }
 
@@ -228,7 +231,10 @@ process DIANN_QUANT {
 
 process DIANN_MBR {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
-    label 'process_high_constant'
+    cpus   32
+    memory { Math.max(16.0, (ms_files*.size().sum() / (1024 ** 3)) * 1.5).GB }
+    time   { 6.m * ms_files.size() }
+    label 'DIANN_MBR'
     container params.images.diann
     stageInMode { params.use_vendor_raw ? 'link' : 'symlink' }
 
@@ -258,6 +264,8 @@ process DIANN_MBR {
         ms_file_args = "--f '${sorted_ms_files.join('\' --f \'')}'"
 
         """
+        echo "There are ${ms_files.size()} files!"
+
         diann ${ms_file_args} \
             --threads ${task.cpus} \
             --fasta ${fasta_file} \
@@ -295,8 +303,11 @@ process DIANN_MBR {
 
 process BLIB_BUILD_LIBRARY {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(8.0, (precursor_report.size() / (1024 ** 3)) * 1.5 ).GB }
+    time   { 2.h * task.attempt }
     label 'proteowizard'
+    label 'BLIB_BUILD_LIBRARY'
     container params.images.proteowizard
 
     input:

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -1,4 +1,7 @@
 
+include { get_total_file_sizes } from './utils.nf'
+include { get_n_files } from './utils.nf'
+
 /**
  * Join multiple MS files into a single string, skipping Bruker .d directories.
  *
@@ -232,8 +235,8 @@ process DIANN_QUANT {
 process DIANN_MBR {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   32
-    memory { Math.max(16.0, (ms_files*.size().sum() / (1024 ** 3)) * 1.5).GB }
-    time   { 10.m * ms_files.size() }
+    memory { Math.max(16.0, (get_total_file_sizes(ms_files) / (1024 ** 3)) * 1.5).GB }
+    time   { 10.m * get_n_files(ms_files) }
     label 'DIANN_MBR'
     container params.images.diann
     stageInMode { params.use_vendor_raw ? 'link' : 'symlink' }
@@ -264,8 +267,6 @@ process DIANN_MBR {
         ms_file_args = "--f '${sorted_ms_files.join('\' --f \'')}'"
 
         """
-        echo "There are ${ms_files.size()} files!"
-
         diann ${ms_file_args} \
             --threads ${task.cpus} \
             --fasta ${fasta_file} \

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -233,7 +233,7 @@ process DIANN_MBR {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   32
     memory { Math.max(16.0, (ms_files*.size().sum() / (1024 ** 3)) * 1.5).GB }
-    time   { 6.m * ms_files.size() }
+    time   { 10.m * ms_files.size() }
     label 'DIANN_MBR'
     container params.images.diann
     stageInMode { params.use_vendor_raw ? 'link' : 'symlink' }

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -198,7 +198,7 @@ process CARAFE_DIANN_SEARCH {
 process DIANN_QUANT {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   8
-    memory { Math.max(8.0, ((ms_file.size() + spectral_library.size()) / (1024 ** 3)) * 1.5).GB }
+    memory { Math.max(16.0, ((ms_file.size() + spectral_library.size()) / (1024 ** 3)) * 2.0).GB }
     time   { 2.h * task.attempt }
     label 'DIANN_QUANT'
     container params.images.diann
@@ -235,7 +235,7 @@ process DIANN_QUANT {
 process DIANN_MBR {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   32
-    memory { Math.max(16.0, (get_total_file_sizes(ms_files) / (1024 ** 3)) * 1.5).GB }
+    memory { Math.max(32.0, (get_total_file_sizes(ms_files) / (1024 ** 3)) * 2.0).GB }
     time   { 10.m * get_n_files(ms_files) }
     label 'DIANN_MBR'
     container params.images.diann

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -10,7 +10,10 @@ process ENCYCLOPEDIA_SEARCH_FILE {
     publishDir params.output_directories.encyclopedia.search_file, pattern: "*.features.txt", failOnError: true, mode: 'copy', enabled: params.encyclopedia.save_output
     publishDir params.output_directories.encyclopedia.search_file, pattern: "*.encyclopedia.txt", failOnError: true, mode: 'copy', enabled: params.encyclopedia.save_output
     publishDir params.output_directories.encyclopedia.search_file, pattern: "*.encyclopedia.decoy.txt", failOnError: true, mode: 'copy', enabled: params.encyclopedia.save_output
-    label 'process_high_constant'
+    cpus   8
+    memory { 16.GB * task.attempt }
+    time   { 4.h  * task.attempt }
+    label 'ENCYCLOPEDIA_SEARCH_FILE'
     container params.images.encyclopedia
 
     input:
@@ -63,7 +66,10 @@ process ENCYCLOPEDIA_SEARCH_FILE {
 
 process ENCYCLOPEDIA_CREATE_ELIB {
     publishDir params.output_directories.encyclopedia.create_elib, failOnError: true, mode: 'copy'
-    label 'process_memory_high_constant'
+    cpus  32
+    memory { Math.max(32, search_elib_files.size() * 4).GB }
+    time   { 24.h  * task.attempt }
+    label 'ENCYCLOPEDIA_CREATE_ELIB'
     container params.images.encyclopedia
 
     input:

--- a/modules/file_stats.nf
+++ b/modules/file_stats.nf
@@ -1,6 +1,8 @@
 
 process CALCULATE_MD5 {
-    label 'process_low'
+    cpus   1
+    memory { Math.max(8.0, (file_to_check.size() / (1024 ** 3)) * 1.5).GB }
+    time   { 15.m * task.attempt }
     container params.images.ubuntu
 
     input:

--- a/modules/pdc.nf
+++ b/modules/pdc.nf
@@ -1,5 +1,5 @@
 
-include { format_flag } from "./qc_report.nf"
+include { format_flag } from "./utils.nf"
 
 process GET_STUDY_METADATA {
     publishDir "${params.result_dir}/pdc", failOnError: true, mode: 'copy'

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -29,7 +29,10 @@ process MAKE_EMPTY_FILE {
 
 process MERGE_REPORTS {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (precursor_reports*.size().sum() / (1024 ** 3))).GB }
+    time   { 8.h * task.attempt }
+    label 'MERGE_REPORTS'
     container params.images.qc_pipeline
 
     input:
@@ -83,7 +86,10 @@ process MERGE_REPORTS {
 process FILTER_IMPUTE_NORMALIZE {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     stageInMode 'copy' // The input file is modified in place. Copying is necissary to avoid problems with caching.
-    label 'process_high_memory'
+    cpus   8
+    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
+    time   { 4.h * task.attempt }
+    label 'FILTER_IMPUTE_NORMALIZE'
     container params.images.qc_pipeline
 
     input:
@@ -123,11 +129,14 @@ process FILTER_IMPUTE_NORMALIZE {
 
 process GENERATE_QC_QMD {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
+    time   { 1.h * task.attempt }
+    label 'GENERATE_QC_QMD'
     container params.images.qc_pipeline
 
     input:
-        val batch
+        val  batch
         path database
 
     output:
@@ -157,8 +166,11 @@ process GENERATE_BATCH_REPORT {
     publishDir params.output_directories.batch_report_tables, pattern: '*.tsv', failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report_plots, pattern: "plots/*.${params.batch_report.plot_ext}", failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report, pattern: '*.std{err,out}', failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (normalized_db.size() / (1024 ** 3)) * 4.0 ).GB }
+    time   { 4.h * task.attempt }
     label 'run_as_root'
+    label 'GENERATE_BATCH_REPORT'
     container params.images.qc_pipeline
 
     input:
@@ -207,7 +219,10 @@ process EXPORT_TABLES {
     publishDir params.output_directories.qc_report_tables, pattern: '*.tsv', failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stdout', failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stderr', failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (precursor_db.size() / (1024 ** 3)) * 2.0 ).GB }
+    time   { 2.h * task.attempt }
+    label 'GENERATE_BATCH_REPORT'
     container params.images.qc_pipeline
 
     input:
@@ -234,8 +249,11 @@ process RENDER_QC_REPORT {
     publishDir params.output_directories.qc_report, pattern: "*.${report_format}", failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stdout', failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stderr', failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 2.0 ).GB }
+    time   { 2.h * task.attempt }
     label 'run_as_root'
+    label 'RENDER_QC_REPORT'
     container params.images.qc_pipeline
 
     input:
@@ -263,7 +281,10 @@ process RENDER_QC_REPORT {
 
 process EXPORT_GENE_REPORTS {
     publishDir params.output_directories.gene_reports, failOnError: true, mode: 'copy'
-    label 'process_high_memory'
+    cpus   2
+    memory { Math.max(16.0, (batch_db.size() / (1024 ** 3)) * 2.0 ).GB }
+    time   { 2.h * task.attempt }
+    label 'EXPORT_GENE_REPORTS'
     container params.images.qc_pipeline
 
     input:

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -46,9 +46,9 @@ process VALIDATE_LOCAL_METADATA {
         echo '${quant_files}' > quant_files.json
         echo '${chrom_lib_files}' > chrom_lib_files.json
 
-        dia_qc validate params
-            --quant-spectra-files quant_files.json \
-            --chrom-lib-files chrom_lib_files.json \
+        dia_qc validate params \
+            --quant-spectra-json quant_files.json \
+            --chrom-lib-spectra-json chrom_lib_files.json \
             --metadata ${replicate_metadata} \
             ${format_flag(params.batch_report.batch1, "--batch1")} \
             ${format_flag(params.batch_report.batch2, "--batch2")} \
@@ -82,9 +82,9 @@ process VALIDATE_PANORAMA_METADATA {
         echo '${quant_files}' > quant_files.json
         echo '${chrom_lib_files}' > chrom_lib_files.json
 
-        dia_qc validate params
-            --quant-spectra-files quant_files.json \
-            --chrom-lib-files chrom_lib_files.json \
+        dia_qc validate params \
+            --quant-spectra-json quant_files.json \
+            --chrom-lib-spectra-json chrom_lib_files.json \
             --metadata ${metadata_webdav_url} --metadata-output-path metadata.${metadata_ext} \
             ${format_flag(params.batch_report.batch1, "--batch1")} \
             ${format_flag(params.batch_report.batch2, "--batch2")} \
@@ -115,9 +115,9 @@ process VALIDATE_PANORAMA_PUBLIC_METADATA {
         echo '${quant_files}' > quant_files.json
         echo '${chrom_lib_files}' > chrom_lib_files.json
 
-        dia_qc validate params
-            --quant-spectra-files quant_files.json \
-            --chrom-lib-files chrom_lib_files.json \
+        dia_qc validate params \
+            --quant-spectra-json quant_files.json \
+            --chrom-lib-spectra-json chrom_lib_files.json \
             --metadata ${metadata_webdav_url} \
             --metadata ${metadata_webdav_url} --metadata-output-path metadata.${metadata_ext} \
             ${format_flag(params.batch_report.batch1, "--batch1")} \

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -227,7 +227,7 @@ process GENERATE_QC_QMD {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     cpus   2
     memory { Math.max(8.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
-    time   { 1.h * task.attempt }
+    time   { 2.h * task.attempt }
     label 'GENERATE_QC_QMD'
     container params.images.qc_pipeline
 

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -75,7 +75,7 @@ process VALIDATE_PANORAMA_METADATA {
         path("${file(metadata_webdav_url).name}") , emit: replicate_metadata
 
     script:
-        metadata_ext = file(metadata_webdav_url).extension
+        metadata_name = file(metadata_webdav_url).name
         """
         ${setupPanoramaAPIKeySecret(aws_secret_id, task.executor)}
 
@@ -85,7 +85,8 @@ process VALIDATE_PANORAMA_METADATA {
         dia_qc validate params \
             --quant-spectra-json quant_files.json \
             --chrom-lib-spectra-json chrom_lib_files.json \
-            --metadata ${metadata_webdav_url} --metadata-output-path metadata.${metadata_ext} \
+            --metadata '${metadata_webdav_url}' \
+            --metadata-output-path '${metadata_name}' \
             ${format_flag(params.batch_report.batch1, "--batch1")} \
             ${format_flag(params.batch_report.batch2, "--batch2")} \
             ${format_flags(params.qc_report.color_vars, "--addColorVar")} \
@@ -110,7 +111,7 @@ process VALIDATE_PANORAMA_PUBLIC_METADATA {
         path("${file(metadata_webdav_url).name}") , emit: replicate_metadata
 
     script:
-        metadata_ext = file(metadata_webdav_url).extension
+        metadata_name = file(metadata_webdav_url).name
         """
         echo '${quant_files}' > quant_files.json
         echo '${chrom_lib_files}' > chrom_lib_files.json
@@ -118,8 +119,8 @@ process VALIDATE_PANORAMA_PUBLIC_METADATA {
         dia_qc validate params \
             --quant-spectra-json quant_files.json \
             --chrom-lib-spectra-json chrom_lib_files.json \
-            --metadata ${metadata_webdav_url} \
-            --metadata ${metadata_webdav_url} --metadata-output-path metadata.${metadata_ext} \
+            --metadata '${metadata_webdav_url}' \
+            --metadata-output-path '${metadata_name}' \
             ${format_flag(params.batch_report.batch1, "--batch1")} \
             ${format_flag(params.batch_report.batch2, "--batch2")} \
             ${format_flags(params.qc_report.color_vars, "--addColorVar")} \

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -1,17 +1,8 @@
 
 include { setupPanoramaAPIKeySecret } from "./panorama"
-
-def format_flag(var, flag) {
-    def ret = (var == null ? "" : "${flag} ${var}")
-    return ret
-}
-
-def format_flags(vars, flag) {
-    if(vars instanceof List) {
-        return (vars == null ? "" : "${flag} \'${vars.join('\' ' + flag + ' \'')}\'")
-    }
-    return format_flag(vars, flag)
-}
+include { format_flag } from "./utils"
+include { format_flags } from "./utils"
+include { get_total_file_sizes } from "./utils"
 
 process MAKE_EMPTY_FILE {
     label 'process_low'

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -135,7 +135,7 @@ process VALIDATE_PANORAMA_PUBLIC_METADATA {
 process MERGE_REPORTS {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (precursor_reports*.size().sum() / (1024 ** 3))).GB }
+    memory { Math.max(8, (precursor_reports*.size().sum() / (1024 ** 3))).GB }
     time   { 8.h * task.attempt }
     label 'MERGE_REPORTS'
     container params.images.qc_pipeline
@@ -192,7 +192,7 @@ process FILTER_IMPUTE_NORMALIZE {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     stageInMode 'copy' // The input file is modified in place. Copying is necissary to avoid problems with caching.
     cpus   8
-    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
+    memory { Math.max(8, (database.size() / (1024 ** 3)) * 1.5 ).GB }
     time   { 4.h * task.attempt }
     label 'FILTER_IMPUTE_NORMALIZE'
     container params.images.qc_pipeline
@@ -235,7 +235,7 @@ process FILTER_IMPUTE_NORMALIZE {
 process GENERATE_QC_QMD {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
+    memory { Math.max(8.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
     time   { 1.h * task.attempt }
     label 'GENERATE_QC_QMD'
     container params.images.qc_pipeline
@@ -272,7 +272,7 @@ process GENERATE_BATCH_REPORT {
     publishDir params.output_directories.batch_report_plots, pattern: "plots/*.${params.batch_report.plot_ext}", failOnError: true, mode: 'copy'
     publishDir params.output_directories.batch_report, pattern: '*.std{err,out}', failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (normalized_db.size() / (1024 ** 3)) * 4.0 ).GB }
+    memory { Math.max(8.0, (normalized_db.size() / (1024 ** 3)) * 4.0 ).GB }
     time   { 4.h * task.attempt }
     label 'run_as_root'
     label 'GENERATE_BATCH_REPORT'
@@ -325,9 +325,9 @@ process EXPORT_TABLES {
     publishDir params.output_directories.qc_report, pattern: '*.stdout', failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stderr', failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (precursor_db.size() / (1024 ** 3)) * 2.0 ).GB }
+    memory { Math.max(8.0, (precursor_db.size() / (1024 ** 3)) * 2.0 ).GB }
     time   { 2.h * task.attempt }
-    label 'GENERATE_BATCH_REPORT'
+    label 'EXPORT_TABLES'
     container params.images.qc_pipeline
 
     input:
@@ -355,7 +355,7 @@ process RENDER_QC_REPORT {
     publishDir params.output_directories.qc_report, pattern: '*.stdout', failOnError: true, mode: 'copy'
     publishDir params.output_directories.qc_report, pattern: '*.stderr', failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (database.size() / (1024 ** 3)) * 2.0 ).GB }
+    memory { Math.max(8.0, (database.size() / (1024 ** 3)) * 2.0 ).GB }
     time   { 2.h * task.attempt }
     label 'run_as_root'
     label 'RENDER_QC_REPORT'
@@ -387,7 +387,7 @@ process RENDER_QC_REPORT {
 process EXPORT_GENE_REPORTS {
     publishDir params.output_directories.gene_reports, failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(16.0, (batch_db.size() / (1024 ** 3)) * 2.0 ).GB }
+    memory { Math.max(8.0, (batch_db.size() / (1024 ** 3)) * 2.0 ).GB }
     time   { 2.h * task.attempt }
     label 'EXPORT_GENE_REPORTS'
     container params.images.qc_pipeline

--- a/modules/qc_report.nf
+++ b/modules/qc_report.nf
@@ -126,7 +126,7 @@ process VALIDATE_PANORAMA_PUBLIC_METADATA {
 process MERGE_REPORTS {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(8, (precursor_reports*.size().sum() / (1024 ** 3))).GB }
+    memory { Math.max(8.0, (get_total_file_sizes(precursor_reports) / (1024 ** 3))).GB }
     time   { 8.h * task.attempt }
     label 'MERGE_REPORTS'
     container params.images.qc_pipeline
@@ -183,7 +183,7 @@ process FILTER_IMPUTE_NORMALIZE {
     publishDir params.output_directories.qc_report, failOnError: true, mode: 'copy'
     stageInMode 'copy' // The input file is modified in place. Copying is necissary to avoid problems with caching.
     cpus   8
-    memory { Math.max(8, (database.size() / (1024 ** 3)) * 1.5 ).GB }
+    memory { Math.max(8.0, (database.size() / (1024 ** 3)) * 1.5 ).GB }
     time   { 4.h * task.attempt }
     label 'FILTER_IMPUTE_NORMALIZE'
     container params.images.qc_pipeline

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -5,10 +5,12 @@ def sky_basename(path) {
 
 process SKYLINE_ADD_LIB {
     publishDir params.output_directories.skyline.add_lib, failOnError: true, mode: 'copy'
-    label 'process_medium'
-    label 'process_short'
+    cpus   4
+    memory { Math.max(15.0, ( elib.size() / (1024 ** 3)) * 1.5 ).GB }
+    time   { 2.h * task.attempt }
     label 'error_retry'
     label 'proteowizard'
+    label 'SKYLINE_ADD_LIB'
     container params.images.proteowizard
 
     input:
@@ -88,13 +90,14 @@ process SKYLINE_ADD_LIB {
 
 process SKYLINE_IMPORT_MS_FILE {
     publishDir params.output_directories.skyline.import_spectra, pattern: '*.std[oe][ur][tr]', failOnError: true, mode: 'copy'
-    label 'process_medium'
-    label 'process_high_memory'
-    label 'process_twohours'
+    cpus   8
+    memory { Math.max(8.0, ((skyline_zipfile.size() + ms_file.size()) / (1024 ** 3)) * 1.5 ).GB }
+    time   { 2.h * task.attempt }
     label 'error_retry'
     label 'proteowizard'
-    container params.images.proteowizard
     cache 'lenient'
+    label 'SKYLINE_IMPORT_MS_FILE'
+    container params.images.proteowizard
     stageInMode "${params.skyline.use_hardlinks && executor != 'awsbatch' ? 'link' : 'symlink'}"
 
     input:
@@ -127,11 +130,14 @@ process SKYLINE_IMPORT_MS_FILE {
 
 process SKYLINE_MERGE_RESULTS {
     publishDir params.output_directories.skyline.import_spectra, enabled: params.replicate_metadata == null && params.pdc.study_id == null, failOnError: true, mode: 'copy'
-    label 'process_high'
+    cpus   32
+    memory { Math.max(8.0, ((skyd_files*.size().sum()) / (1024 ** 3)) * 1.5).GB }
+    time   { 8.h * task.attempt }
     label 'error_retry'
     label 'proteowizard'
-    container params.images.proteowizard
     cache 'lenient'
+    label 'SKYLINE_MERGE_RESULTS'
+    container params.images.proteowizard
     stageInMode "${params.skyline.use_hardlinks && executor != 'awsbatch' ? 'link' : 'symlink'}"
 
     input:
@@ -182,7 +188,6 @@ process SKYLINE_MERGE_RESULTS {
 process ANNOTATION_TSV_TO_CSV {
     publishDir params.output_directories.skyline.import_spectra, failOnError: true, mode: 'copy'
     label 'process_low'
-    label 'error_retry'
     container params.images.qc_pipeline
 
     input:
@@ -246,8 +251,11 @@ process SKYLINE_MINIMIZE_DOCUMENT {
 
 process SKYLINE_ANNOTATE_DOCUMENT {
     publishDir params.output_directories.skyline.import_spectra, failOnError: true, mode: 'copy'
-    label 'process_memory_high_constant'
+    cpus   8
+    memory { Math.max(8.0, (skyline_zipfile.size() / (1024 ** 3)) * 1.5).GB }
+    time   { 4.h * task.attempt }
     label 'proteowizard'
+    label 'SKYLINE_ANNOTATE_DOCUMENT'
     container params.images.proteowizard
 
     input:
@@ -288,9 +296,13 @@ process SKYLINE_ANNOTATE_DOCUMENT {
 
 process SKYLINE_RUN_REPORTS {
     publishDir params.output_directories.skyline.reports, failOnError: true, mode: 'copy'
+    cpus   8
+    memory { Math.max(8.0, (skyline_zipfile.size() / (1024 ** 3)) * 1.5).GB }
+    time   { 4.h * task.attempt }
     label 'process_high'
     label 'error_retry'
     label 'proteowizard'
+    label 'SKYLINE_RUN_REPORTS'
     container params.images.proteowizard
 
     input:

--- a/modules/skyline.nf
+++ b/modules/skyline.nf
@@ -6,7 +6,7 @@ def sky_basename(path) {
 process SKYLINE_ADD_LIB {
     publishDir params.output_directories.skyline.add_lib, failOnError: true, mode: 'copy'
     cpus   4
-    memory { Math.max(15.0, ( elib.size() / (1024 ** 3)) * 1.5 ).GB }
+    memory { Math.max(8.0, ( elib.size() / (1024 ** 3)) * 1.5 ).GB }
     time   { 2.h * task.attempt }
     label 'error_retry'
     label 'proteowizard'

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,0 +1,89 @@
+
+/**
+* Process a parameter variable which is specified as either a single value or List.
+* If param_variable has multiple lines, each line with text is returned as an
+* element in a List.
+*
+* @param param_variable A parameter variable which can either be a single value or List.
+* @return param_variable as a List with 1 or more values.
+*/
+def param_to_list(param_variable) {
+    if(param_variable instanceof List) {
+        return param_variable
+    }
+    if(param_variable instanceof String) {
+        // Split string by new line, remove whitespace, and skip empty lines
+        return param_variable.split('\n').collect{ it.trim() }.findAll{ it }
+    }
+    return [param_variable]
+}
+
+/**
+ * Format a variable with a flag.
+ *
+ * If the variable is null, an empty string is returned.
+ * Otherwise, the variable is formatted as "${flag} ${var}".
+ *
+ * @param var The variable to format.
+ * @param flag The flag to prepend to the variable.
+ * @return The formatted string.
+ */
+def format_flag(var, flag) {
+    def ret = (var == null ? "" : "${flag} ${var}")
+    return ret
+}
+
+/**
+ * Format a variable with a flag.
+ *
+ * If the variable is null, an empty string is returned.
+ * If the variable is a List, each element is formatted with the flag and joined by spaces.
+ * Otherwise, the variable is formatted as "${flag} ${var}".
+ *
+ * @param vars The variable or List of variables to format.
+ * @param flag The flag to prepend to each variable.
+ * @return The formatted string.
+ */
+def format_flags(vars, flag) {
+    if(vars instanceof List) {
+        return (vars == null ? "" : "${flag} \'${vars.join('\' ' + flag + ' \'')}\'")
+    }
+    return format_flag(vars, flag)
+}
+
+/**
+ * Get the total size of files in the files variable.
+ *
+ * If the collect() opperator is called on a Channel of paths,
+ * it will emit a List of Paths if there is more than one file,
+ * but a single Path object if there is only one file in the channel.
+ * This function handles both cases.
+ *
+ * @param files A List of Paths or a single Path.
+ * @return The number of files as an integer.
+ */
+def get_total_file_sizes(files) {
+    if(files instanceof List<Path>) {
+        return files*.size().sum()
+    } else if(files instanceof Path) {
+        return files.size()
+    } else {
+        error "Unknown type: ${files.getClass()}"
+    }
+}
+
+/**
+ * Get the number of files in the files variable.
+ *
+ * @param files A List of Paths or a single Path.
+ * @return The number of files as an integer.
+ */
+def get_n_files(files) {
+    if(files instanceof List<Path>) {
+        return files.size()
+    } else if(files instanceof Path){
+        return 1
+    } else {
+        error "Unknown type: ${files.getClass()}"
+    }
+}

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -54,13 +54,13 @@ def format_flags(vars, flag) {
 /**
  * Get the total size of files in the files variable.
  *
- * If the collect() opperator is called on a Channel of paths,
- * it will emit a List of Paths if there is more than one file,
+ * If the collect() opperator is called on a Channel of Paths,
+ * it will emit a List<Path> if there is more than one file,
  * but a single Path object if there is only one file in the channel.
- * This function handles both cases.
+ * This function handles both variable types.
  *
- * @param files A List of Paths or a single Path.
- * @return The number of files as an integer.
+ * @param files A List<Path> or a single Path.
+ * @return The total size of the files as an integer.
  */
 def get_total_file_sizes(files) {
     if(files instanceof List<Path>) {
@@ -75,7 +75,7 @@ def get_total_file_sizes(files) {
 /**
  * Get the number of files in the files variable.
  *
- * @param files A List of Paths or a single Path.
+ * @param files A List<Path> or a single Path.
  * @return The number of files as an integer.
  */
 def get_n_files(files) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -257,7 +257,7 @@ manifest {
     homePage        = 'https://github.com/mriffle/nf-skyline-dia-ms'
     description     = 'DIA workflows for TEI-REX project'
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.04.2'
+    nextflowVersion = '!>=24.04.0'
 }
 
 // Capture exit codes from upstream processes when piping
@@ -288,36 +288,3 @@ includeConfig 'container_images.config'
 
 // Load the output file directories
 includeConfig 'conf/output_directories.config'
-
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit. Copied from the nf-core template.
-def check_max(obj, type) {
-    if (type == 'memory') {
-        try {
-            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-                return params.max_memory as nextflow.util.MemoryUnit
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'time') {
-        try {
-            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-                return params.max_time as nextflow.util.Duration
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'cpus') {
-        try {
-            return Math.min( obj, params.max_cpus as int )
-        } catch (all) {
-            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
-            return obj
-        }
-    }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -175,6 +175,7 @@ params {
 
 plugins {
     id 'nf-amazon'
+    id 'nf-schema@2.4.1'
 }
 
 docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
         peptide_results_file = null
         carafe_fasta = null
         diann_fasta = null
-        cli_options = ''
+        cli_options = '-min_pep_charge 2 -max_pep_charge 3'
     }
 
     // the data to be quantified

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,10 +17,12 @@ params {
     // the data to be quantified
     quant_spectra_dir = null      // directory containing the raw data
     quant_spectra_glob = '*.raw'  // which files in this directory to use
+    quant_spectra_regex = null // regex to match files in quant_spectra_glob
 
     // the data to be used to generate a chromatogram library (e.g. narrow window GPF data)
     chromatogram_library_spectra_dir = null     // directory containing the raw data
     chromatogram_library_spectra_glob = '*.raw' // which files in this directory to use
+    chromatogram_library_spectra_regex = null // regex to match files in chromatogram_library_spectra_glob
 
     spectral_library = null                 // can be blib, dlib, or elib
     fasta = null                            // background FASTA

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -512,13 +512,6 @@
       "type": "string",
       "default": "/data/mass_spec/nextflow/panorama/raw_cache"
     },
-    "images": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      },
-      "hidden": true
-    },
     "output_directories": {
       "type": "object",
       "additionalProperties": {
@@ -534,6 +527,63 @@
           }
         ]
       },
+      "hidden": true
+    },
+    "images": {
+      "type": "object",
+      "properties": {
+        "ubuntu": {
+          "type": "string"
+        },
+        "diann": {
+          "type": "string"
+        },
+        "bibliospec": {
+          "type": "string"
+        },
+        "panorama_client": {
+          "type": "string"
+        },
+        "pdc_client": {
+          "type": "string"
+        },
+        "encyclopedia": {
+          "type": "string"
+        },
+        "encyclopedia3_mriffle": {
+          "type": "string"
+        },
+        "qc_pipeline": {
+          "type": "string"
+        },
+        "proteowizard": {
+          "type": "string"
+        },
+        "cascadia": {
+          "type": "string"
+        },
+        "cascadia_utils": {
+          "type": "string"
+        },
+        "carafe": {
+          "type": "string"
+        }
+      },
+      "default": {
+        "ubuntu": "ubuntu:22.04",
+        "diann": "quay.io/protio/diann:1.8.1",
+        "bibliospec": "quay.io/protio/bibliospec-linux:3.0",
+        "panorama_client": "quay.io/protio/panorama-client:1.1.0",
+        "pdc_client": "quay.io/mauraisa/pdc_client:2.2.0",
+        "encyclopedia": "quay.io/protio/encyclopedia:2.12.30-2",
+        "encyclopedia3_mriffle": "quay.io/protio/encyclopedia:3.0.0-MRIFFLE",
+        "qc_pipeline": "quay.io/mauraisa/dia_qc_report:2.4.3",
+        "proteowizard": "quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997",
+        "cascadia": "quay.io/protio/cascadia:0.0.7",
+        "cascadia_utils": "quay.io/protio/cascadia-utils:0.0.4",
+        "carafe": "quay.io/mauraisa/carafe:0.0.1-beta"
+      },
+      "additionalProperties": false,
       "hidden": true
     }
   }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -7,7 +7,9 @@
   "properties": {
     "quant_spectra_dir": {
       "anyOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "array",
           "items": {
@@ -26,9 +28,14 @@
       "type": "string",
       "default": "*.raw"
     },
+    "quant_spectra_regex": {
+      "type": "string"
+    },
     "chromatogram_library_spectra_dir": {
       "anyOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "array",
           "items": {
@@ -40,6 +47,9 @@
     "chromatogram_library_spectra_glob": {
       "type": "string",
       "default": "*.raw"
+    },
+    "chromatogram_library_spectra_regex": {
+      "type": "string"
     },
     "spectral_library": {
       "type": "string"
@@ -74,7 +84,9 @@
     },
     "skyline_skyr_file": {
       "anyOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "array",
           "items": {
@@ -206,18 +218,12 @@
         },
         "imputation_method": {
           "type": "string",
-          "enum": [
-            "knn"
-          ]
+          "enum": ["knn"]
         },
         "normalization_method": {
           "type": "string",
           "default": "median",
-          "enum": [
-            "median",
-            "DirectLFQ",
-            "directlfq"
-          ]
+          "enum": ["median", "DirectLFQ", "directlfq"]
         },
         "standard_proteins": {
           "anyOf": [

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -536,6 +536,5 @@
       },
       "hidden": true
     }
-  },
-  "required": ["images", "output_directories"]
+  }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,535 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/nf-skyline-dia-ms//nextflow_schema.json",
+  "title": "nf-skyline-dia-ms pipeline parameters",
+  "description": "DIA workflows for TEI-REX project",
+  "type": "object",
+  "properties": {
+    "quant_spectra_dir": {
+      "anyOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "quant_spectra_glob": {
+      "type": "string",
+      "default": "*.raw"
+    },
+    "chromatogram_library_spectra_dir": {
+      "anyOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "chromatogram_library_spectra_glob": {
+      "type": "string",
+      "default": "*.raw"
+    },
+    "spectral_library": {
+      "type": "string"
+    },
+    "fasta": {
+      "type": "string"
+    },
+    "files_per_quant_batch": {
+      "type": "integer"
+    },
+    "files_per_chrom_lib": {
+      "type": "integer"
+    },
+    "random_file_seed": {
+      "type": "integer",
+      "default": 12
+    },
+    "use_vendor_raw": {
+      "type": "boolean"
+    },
+    "skyline_document_name": {
+      "type": "string",
+      "hidden": true
+    },
+    "skyline_template_file": {
+      "type": "string",
+      "hidden": true
+    },
+    "skip_skyline": {
+      "type": "boolean",
+      "hidden": true
+    },
+    "skyline_skyr_file": {
+      "anyOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
+      "hidden": true
+    },
+    "search_engine": {
+      "type": "string",
+      "default": "encyclopedia",
+      "enum": [
+        "diann",
+        "encyclopedia",
+        "cascadia",
+        "DiaNN",
+        "EncyclopeDIA",
+        "CascaDIA",
+        "Cascadia"
+      ]
+    },
+    "email": {
+      "type": "string"
+    },
+    "panorama_upload": {
+      "type": "boolean"
+    },
+    "msconvert_only": {
+      "type": "boolean"
+    },
+    "replicate_metadata": {
+      "type": "string"
+    },
+    "pdc": {
+      "type": "object",
+      "properties": {
+        "client_args": {
+          "type": "string",
+          "default": ""
+        },
+        "study_id": {
+          "type": "string"
+        },
+        "n_raw_files": {
+          "type": "integer"
+        },
+        "metadata_tsv": {
+          "type": "string"
+        },
+        "gene_level_data": {
+          "type": "string"
+        },
+        "s3_download": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "carafe": {
+      "type": "object",
+      "properties": {
+        "spectra_file": {
+          "type": "string"
+        },
+        "peptide_results_file": {
+          "type": "string"
+        },
+        "carafe_fasta": {
+          "type": "string"
+        },
+        "diann_fasta": {
+          "type": "string"
+        },
+        "cli_options": {
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "msconvert": {
+      "type": "object",
+      "properties": {
+        "do_demultiplex": {
+          "type": "boolean",
+          "default": true
+        },
+        "do_simasspectra": {
+          "type": "boolean",
+          "default": true
+        },
+        "mz_shift_ppm": {
+          "type": "number"
+        }
+      }
+    },
+    "qc_report": {
+      "type": "object",
+      "properties": {
+        "skip": {
+          "type": "boolean",
+          "default": true
+        },
+        "exclude_replicates": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "exclude_projects": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "imputation_method": {
+          "type": "string",
+          "enum": [
+            "knn"
+          ]
+        },
+        "normalization_method": {
+          "type": "string",
+          "default": "median",
+          "enum": [
+            "median",
+            "DirectLFQ",
+            "directlfq"
+          ]
+        },
+        "standard_proteins": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "color_vars": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "export_tables": {
+          "type": "boolean",
+          "default": false
+        },
+        "precursor_report_template": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/ajmaurais/DIA_QC_report/master/resources/precursor_quality.skyr"
+        },
+        "replicate_report_template": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/ajmaurais/DIA_QC_report/master/resources/replicate_quality.skyr"
+        }
+      }
+    },
+    "batch_report": {
+      "type": "object",
+      "properties": {
+        "skip": {
+          "type": "boolean",
+          "default": true
+        },
+        "batch1": {
+          "type": "string"
+        },
+        "batch2": {
+          "type": "string"
+        },
+        "covariate_vars": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "control_key": {
+          "type": "string"
+        },
+        "control_values": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "plot_ext": {
+          "type": "string"
+        }
+      }
+    },
+    "aws": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string",
+          "default": "us-west-2"
+        },
+        "batch": {
+          "type": "object",
+          "properties": {
+            "cliPath": {
+              "type": "string",
+              "default": "/usr/local/aws-cli/v2/current/bin/aws"
+            },
+            "logsGroup": {
+              "type": "string",
+              "default": "/batch/tei-nextflow-batch"
+            },
+            "maxConnections": {
+              "type": "integer",
+              "default": 20
+            },
+            "connectionTimeout": {
+              "type": "integer",
+              "default": 10000
+            },
+            "uploadStorageClass": {
+              "type": "string",
+              "default": "INTELLIGENT_TIERING"
+            },
+            "storageEncryption": {
+              "type": "string",
+              "default": "AES256"
+            },
+            "retryMode": {
+              "type": "string",
+              "default": "standard"
+            }
+          }
+        }
+      }
+    },
+    "diann": {
+      "type": "object",
+      "properties": {
+        "search_params": {
+          "type": "string",
+          "default": "--qvalue 0.01"
+        },
+        "fasta_digest_params": {
+          "type": "string",
+          "default": "--cut 'K*,R*,!*P' --unimod4 --missed-cleavages 1 --min-pep-len 8 --min-pr-charge 2 --max-pep-len 30"
+        }
+      }
+    },
+    "encyclopedia": {
+      "type": "object",
+      "properties": {
+        "quant": {
+          "type": "object",
+          "properties": {
+            "params": {
+              "type": "string",
+              "default": "-enableAdvancedOptions -v2scoring"
+            }
+          }
+        },
+        "chromatogram": {
+          "type": "object",
+          "properties": {
+            "params": {
+              "type": "string",
+              "default": "-enableAdvancedOptions -v2scoring"
+            }
+          }
+        },
+        "save_output": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "cascadia": {
+      "type": "object",
+      "properties": {
+        "use_gpu": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "panorama": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "default": "https://panoramaweb.org"
+        },
+        "public": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "default": "7d503a4147133c448c6eaf83bc9b8bc22ace4b7f6d36ca61c9d1ca836c510d10"
+            }
+          }
+        },
+        "upload": {
+          "type": "boolean",
+          "default": false
+        },
+        "upload_url": {
+          "type": "string"
+        },
+        "import_skyline": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "skyline": {
+      "type": "object",
+      "properties": {
+        "document_name": {
+          "type": "string",
+          "default": "final"
+        },
+        "template_file": {
+          "type": "string"
+        },
+        "skip": {
+          "type": "boolean",
+          "default": false
+        },
+        "skyr_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "minimize": {
+          "type": "boolean",
+          "default": false
+        },
+        "group_by_gene": {
+          "type": "boolean",
+          "default": false
+        },
+        "protein_parsimony": {
+          "type": "boolean",
+          "default": false
+        },
+        "fasta": {
+          "type": "string"
+        },
+        "use_hardlinks": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "result_dir": {
+      "type": "string",
+      "default": "results/nf-skyline-dia-ms"
+    },
+    "report_dir": {
+      "type": "string",
+      "default": "reports/nf-skyline-dia-ms"
+    },
+    "default_skyline_template_file": {
+      "type": "string",
+      "default": "https://github.com/mriffle/nf-skyline-dia-ms/raw/main/resources/template.sky.zip"
+    },
+    "max_memory": {
+      "type": "string",
+      "default": "12.GB"
+    },
+    "max_cpus": {
+      "type": "integer",
+      "default": 8
+    },
+    "max_time": {
+      "type": "string",
+      "default": "240.h"
+    },
+    "mzml_cache_directory": {
+      "type": "string",
+      "default": "/data/mass_spec/nextflow/nf-skyline-dia-ms/mzml_cache"
+    },
+    "panorama_cache_directory": {
+      "type": "string",
+      "default": "/data/mass_spec/nextflow/panorama/raw_cache"
+    },
+    "images": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "hidden": true
+    },
+    "output_directories": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "hidden": true
+    }
+  },
+  "required": ["images", "output_directories"]
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -218,7 +218,7 @@
         },
         "imputation_method": {
           "type": "string",
-          "enum": ["knn"]
+          "enum": ["KNN", "knn"]
         },
         "normalization_method": {
           "type": "string",
@@ -533,55 +533,53 @@
       "type": "object",
       "properties": {
         "ubuntu": {
-          "type": "string"
+          "type": "string",
+          "default": "ubuntu:22.04"
         },
         "diann": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/diann:1.8.1"
         },
         "bibliospec": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/bibliospec-linux:3.0"
         },
         "panorama_client": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/panorama-client:1.1.0"
         },
         "pdc_client": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/mauraisa/pdc_client:2.2.0"
         },
         "encyclopedia": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/encyclopedia:2.12.30-2"
         },
         "encyclopedia3_mriffle": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/encyclopedia:3.0.0-MRIFFLE"
         },
         "qc_pipeline": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/mauraisa/dia_qc_report:2.4.3"
         },
         "proteowizard": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997"
         },
         "cascadia": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/cascadia:0.0.7"
         },
         "cascadia_utils": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/protio/cascadia-utils:0.0.4"
         },
         "carafe": {
-          "type": "string"
+          "type": "string",
+          "default": "quay.io/mauraisa/carafe:0.0.1-beta"
         }
-      },
-      "default": {
-        "ubuntu": "ubuntu:22.04",
-        "diann": "quay.io/protio/diann:1.8.1",
-        "bibliospec": "quay.io/protio/bibliospec-linux:3.0",
-        "panorama_client": "quay.io/protio/panorama-client:1.1.0",
-        "pdc_client": "quay.io/mauraisa/pdc_client:2.2.0",
-        "encyclopedia": "quay.io/protio/encyclopedia:2.12.30-2",
-        "encyclopedia3_mriffle": "quay.io/protio/encyclopedia:3.0.0-MRIFFLE",
-        "qc_pipeline": "quay.io/mauraisa/dia_qc_report:2.4.3",
-        "proteowizard": "quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997",
-        "cascadia": "quay.io/protio/cascadia:0.0.7",
-        "cascadia_utils": "quay.io/protio/cascadia-utils:0.0.4",
-        "carafe": "quay.io/mauraisa/carafe:0.0.1-beta"
       },
       "additionalProperties": false,
       "hidden": true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -562,7 +562,7 @@
         },
         "qc_pipeline": {
           "type": "string",
-          "default": "quay.io/mauraisa/dia_qc_report:2.4.3"
+          "default": "quay.io/mauraisa/dia_qc_report:2.5.2"
         },
         "proteowizard": {
           "type": "string",

--- a/subworkflows/encyclopedia/encyclopedia_search.nf
+++ b/subworkflows/encyclopedia/encyclopedia_search.nf
@@ -25,7 +25,6 @@ workflow encyclopedia_search {
             encyclopedia_params
         )
 
-
         // aggregate results into single elib
         ENCYCLOPEDIA_CREATE_ELIB(
             ENCYCLOPEDIA_SEARCH_FILE.out.elib.collect(),

--- a/subworkflows/get_input_files.nf
+++ b/subworkflows/get_input_files.nf
@@ -3,8 +3,6 @@ include { PANORAMA_GET_FILE as PANORAMA_GET_FASTA } from "../modules/panorama"
 include { PANORAMA_GET_FILE as PANORAMA_GET_SPECTRAL_LIBRARY } from "../modules/panorama"
 include { PANORAMA_GET_FILE as PANORAMA_GET_SKYLINE_TEMPLATE } from "../modules/panorama"
 include { PANORAMA_GET_SKYR_FILE } from "../modules/panorama"
-include { PANORAMA_GET_FILE as PANORAMA_GET_METADATA } from "../modules/panorama"
-include { MAKE_EMPTY_FILE as METADATA_PLACEHOLDER } from "../modules/qc_report"
 
 /**
 * Process a parameter variable which is specified as either a single value or List.
@@ -95,27 +93,12 @@ workflow get_input_files {
             skyr_files = Channel.empty()
         }
 
-        if(params.replicate_metadata != null) {
-            if(panorama_auth_required_for_url(params.replicate_metadata.trim())) {
-                PANORAMA_GET_METADATA(params.replicate_metadata, aws_secret_id)
-                replicate_metadata = PANORAMA_GET_METADATA.out.panorama_file
-            } else {
-                replicate_metadata = params.replicate_metadata
-            }
-        } else if(params.pdc.study_id != null) {
-            replicate_metadata = null
-        } else {
-            METADATA_PLACEHOLDER('EMPTY')
-            replicate_metadata = METADATA_PLACEHOLDER.out
-        }
-
    emit:
        fasta
        skyline_fasta
        spectral_library
        skyline_template_zipfile
        skyr_files
-       replicate_metadata
 }
 
 // return true if the URL requires panorama authentication (panorama public does not)

--- a/subworkflows/get_input_files.nf
+++ b/subworkflows/get_input_files.nf
@@ -4,24 +4,7 @@ include { PANORAMA_GET_FILE as PANORAMA_GET_SPECTRAL_LIBRARY } from "../modules/
 include { PANORAMA_GET_FILE as PANORAMA_GET_SKYLINE_TEMPLATE } from "../modules/panorama"
 include { PANORAMA_GET_SKYR_FILE } from "../modules/panorama"
 
-/**
-* Process a parameter variable which is specified as either a single value or List.
-* If param_variable has multiple lines, each line with text is returned as an
-* element in a List.
-*
-* @param param_variable A parameter variable which can either be a single value or List.
-* @return param_variable as a List with 1 or more values.
-*/
-def param_to_list(param_variable) {
-    if(param_variable instanceof List) {
-        return param_variable
-    }
-    if(param_variable instanceof String) {
-        // Split string by new line, remove whitespace, and skip empty lines
-        return param_variable.split('\n').collect{ it.trim() }.findAll{ it }
-    }
-    return [param_variable]
-}
+include { param_to_list } from "../modules/utils.nf"
 
 workflow get_input_files {
 

--- a/subworkflows/get_ms_files.nf
+++ b/subworkflows/get_ms_files.nf
@@ -7,7 +7,7 @@ include { MSCONVERT_MULTI_BATCH as MSCONVERT } from "../modules/msconvert"
 include { UNZIP_DIRECTORY as UNZIP_BRUKER_D } from "../modules/msconvert"
 
 // useful functions and variables
-include { param_to_list } from "./get_input_files"
+include { param_to_list } from "../modules/utils.nf"
 
 /**
  * Randomly sample a list and return a list with n elements.

--- a/subworkflows/get_ms_files.nf
+++ b/subworkflows/get_ms_files.nf
@@ -86,7 +86,8 @@ workflow get_ms_files {
             .set{panorama_public_url_ch}
 
         panorama_url_ch
-            .concat(panorama_public_url_ch, local_file_ch)
+            .concat(panorama_public_url_ch)
+            .concat(local_file_ch.map{ batch, file -> [batch, file.name] })
             .tap{ batched_paths_ch }
             .map{ _, path -> path }
             .set{ all_paths_ch }

--- a/subworkflows/get_replicate_metadata.nf
+++ b/subworkflows/get_replicate_metadata.nf
@@ -1,0 +1,45 @@
+
+include { VALIDATE_LOCAL_METADATA } from "../modules/qc_report"
+include { VALIDATE_PANORAMA_METADATA } from "../modules/qc_report"
+include { VALIDATE_PANORAMA_PUBLIC_METADATA } from "../modules/qc_report"
+include { MAKE_EMPTY_FILE as METADATA_PLACEHOLDER } from "../modules/qc_report"
+
+include { panorama_auth_required_for_url } from "./get_input_files"
+
+workflow get_replicate_metadata {
+    take:
+        quant_spectra_file_json
+        chrom_lib_file_json
+        aws_secret_id
+
+    main:
+        if(params.replicate_metadata != null) {
+            if(panorama_auth_required_for_url(params.replicate_metadata.trim())) {
+                VALIDATE_PANORAMA_METADATA(
+                    quant_spectra_file_json, chrom_lib_file_json,
+                    params.replicate_metadata, aws_secret_id
+                )
+                validated_metadata = VALIDATE_PANORAMA_METADATA.out.replicate_metadata
+            } else if (params.replicate_metadata.startsWith(params.panorama.domain)) {
+                VALIDATE_PANORAMA_PUBLIC_METADATA(
+                    quant_spectra_file_json, chrom_lib_file_json,
+                    params.replicate_metadata
+                )
+                validated_metadata = VALIDATE_PANORAMA_PUBLIC_METADATA.out.replicate_metadata
+            } else {
+                VALIDATE_LOCAL_METADATA(
+                    quant_spectra_file_json, chrom_lib_file_json,
+                    file(params.replicate_metadata, checkIfExists: true)
+                )
+                validated_metadata = VALIDATE_LOCAL_METADATA.out.replicate_metadata
+            }
+        } else if(params.pdc.study_id != null) {
+            validated_metadata = null
+        } else {
+            METADATA_PLACEHOLDER('EMPTY')
+            validated_metadata = METADATA_PLACEHOLDER.out
+        }
+
+    emit:
+        validated_metadata
+}


### PR DESCRIPTION
## Changes to process resource requests
* Use `resourceLimits` directive instead of `check_max` function
* Request dynamic memory and run time for resource intensive processes.

## Improved error checking in pipeline.params file
* Check the pipeline params file against a schema with the `validateParameters` function from the `nf-schema` nextflow plugin
* Validate replicate metadata against user specified parameters using new `dia_qc validate` subcommand

## Changes to default pipeline parameters
* Change default Carafe predicted precursor range from `+2, +3, +4` to `+2, +3`.

## New  `quant_spectra_regex` and `chromatogram_library_spectra_regex` parameters
* By default the `glob` parameters are still used.
* The pipeline will check that either the `regex` or `glob` parameters can be specified.
* If both the `regex` and `glob` parameter is specified the pipeline will exit with an error.