### PR TITLE
Update dia qc report

### DIFF
--- a/container_images.config
+++ b/container_images.config
@@ -7,7 +7,7 @@ params {
         pdc_client:            'quay.io/mauraisa/pdc_client:2.3.0',
         encyclopedia:          'quay.io/protio/encyclopedia:2.12.30-2',
         encyclopedia3_mriffle: 'quay.io/protio/encyclopedia:3.0.0-MRIFFLE',
-        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.0',
+        qc_pipeline:           'quay.io/mauraisa/dia_qc_report:2.6.2',
         proteowizard:          'quay.io/mauraisa/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_25.0.9.97-ae4c997',
         cascadia:              'quay.io/protio/cascadia:0.0.7',
         cascadia_utils:        'quay.io/protio/cascadia-utils:0.0.4',

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -310,7 +310,7 @@ def get_blib_name() {
 process BLIB_BUILD_LIBRARY {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   2
-    memory { Math.max(8.0, (precursor_report.size() / (1024 ** 3)) * 1.5 ).GB }
+    memory { Math.max(32.0, (precursor_report.size() / (1024 ** 3)) * 5 ).GB }
     time   { 2.h * task.attempt }
     label 'proteowizard'
     container params.images.proteowizard

--- a/modules/diann.nf
+++ b/modules/diann.nf
@@ -300,6 +300,13 @@ process DIANN_MBR {
         """
 }
 
+def get_blib_name() {
+    if( params.skyline.document_name != null ){
+        return "${params.skyline.document_name}_diann_lib.blib"
+    }
+    return 'lib.blib'
+}
+
 process BLIB_BUILD_LIBRARY {
     publishDir params.output_directories.diann, failOnError: true, mode: 'copy'
     cpus   2
@@ -313,15 +320,15 @@ process BLIB_BUILD_LIBRARY {
         path precursor_report
 
     output:
-        path('lib.blib'), emit: blib
+        path("${get_blib_name()}"), emit: blib
 
     script:
         """
-        wine BlibBuild "${speclib}" lib.blib
+        wine BlibBuild "${speclib}" "${get_blib_name()}"
         """
 
     stub:
         """
-        touch lib.blib
+        touch "${get_blib_name()}"
         """
 }


### PR DESCRIPTION
* Update `qc_report` container to fix issue with empty rows in Skyline reports
* Use `params.skyline.document_name` to name DiaNN blib file that gets used in Skyline (requested by Genn)
    * Instead of `lib.blib` the file will be named `<params.skyline.document_name>_diann_lib.blib`
* Add more base memory for `BLIB_BUILD_LIBRARY`